### PR TITLE
fix: correct template syntax from ${} to {{}} in community sports form

### DIFF
--- a/schemas/community-sports-programme.json
+++ b/schemas/community-sports-programme.json
@@ -226,7 +226,7 @@
       "type": "email",
       "config": {
         "to": "{{db:community-sports-registration:admin_email}}",
-        "subject": "New Community Sports Programme Registration - ${formData.firstName} ${formData.lastName}",
+        "subject": "New Community Sports Programme Registration - {{formData.firstName}} {{formData.lastName}}",
         "template": "community-sports-registration"
       }
     }


### PR DESCRIPTION
## Description
<!-- Summarize the changes based on added/changed functionality --><!-- Summarize the changes based on added/changed functionality -->

This PR fixes the template variable syntax in the community-sports-programme.json schema file to correctly interpolate form data in email subjects.


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

<!--List the files changed and why -->

### Notes
<!--Add notes for anything unrelated to the specified categories -->

## Testing
- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->


## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
