### PR TITLE
fix: update ID Number field to be optional in postal address change form

### DIFF
--- a/schemas/change-your-postal-address.json
+++ b/schemas/change-your-postal-address.json
@@ -45,10 +45,8 @@
           "name": "idNumber",
           "type": "number",
           "label": "ID Number",
-          "required": true,
+          "required": false,
           "validations": {
-            "min": 100000,
-            "max": 999999999,
             "message": "ID Number must be a valid number"
           }
         }
@@ -178,10 +176,8 @@
           "name": "idNumber",
           "type": "number",
           "label": "ID Number",
-          "required": true,
+          "required": false,
           "validations": {
-            "min": 100000,
-            "max": 999999999,
             "message": "ID Number must be a valid number"
           }
         },


### PR DESCRIPTION
## Description
<!-- Summarize the changes based on added/changed functionality --><!-- Summarize the changes based on added/changed functionality -->
Update ID Number field to be optional in postal address change form

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update