### PR TITLE
feat: renamed postal address to redirection notice form schema and email template

### DIFF
--- a/schemas/post-office-redirection-notice.json
+++ b/schemas/post-office-redirection-notice.json
@@ -1,7 +1,7 @@
 {
-  "id": "change-your-postal-address",
-  "name": "Change Your Postal Address",
-  "description": "Form to change your postal address",
+  "id": "post-office-redirection-notice",
+  "name": "Post Office Redirection Notice",
+  "description": "Form to submit a post office redirection notice",
   "fields": [
     {
       "name": "personal",
@@ -227,9 +227,9 @@
     {
       "type": "email",
       "config": {
-        "to": "{{db:change-your-postal-address:admin_email}}",
-        "subject": "New Postal Address Change Request - {{formData.personal.firstName}} {{formData.personal.lastName}}",
-        "template": "change-postal-address"
+        "to": "{{db:post-office-redirection-notice:admin_email}}",
+        "subject": "New Post Office Redirection Notice Request - {{formData.personal.firstName}} {{formData.personal.lastName}}",
+        "template": "post-office-redirection-notice"
       }
     }
   ]

--- a/src/email/templates/post-office-redirection-notice.hbs
+++ b/src/email/templates/post-office-redirection-notice.hbs
@@ -23,11 +23,11 @@
   </head>
   <body>
     <div class='header'>
-      <h1>📮 Change Your Postal Address Request</h1>
+      <h1>📮 Post Office Redirection Notice Request</h1>
     </div>
 
     <div class='content'>
-      <p>A new postal address change request has been submitted.</p>
+      <p>A new post office redirection notice request has been submitted.</p>
 
       <div class='section'>
         <div class='section-title'>Personal Information</div>
@@ -47,7 +47,7 @@
       </div>
 
       <div class='section'>
-        <div class='section-title'>Address Change Details</div>
+        <div class='section-title'>Address Redirection Details</div>
         <div class='address-comparison'>
           <div class='address-box old-address'>
             <h4>Old Address</h4>


### PR DESCRIPTION
## Description
# Rename Form: Change Your Postal Address → Post Office Redirection Notice

## Summary
Renamed the "change-your-postal-address" form to "post-office-redirection-notice" across the entire codebase.

## Changes
- **Schema**: `change-your-postal-address.json` → `post-office-redirection-notice.json`
- **Email Template**: `change-postal-address.hbs` → `post-office-redirection-notice.hbs`
- Updated all internal references (IDs, template names, email subjects)
- Updated form title and description text

## Files Changed
- `schemas/post-office-redirection-notice.json` (renamed + updated content)
- `src/email/templates/post-office-redirection-notice.hbs` (renamed + updated content)

## Testing
- [ ] Verify form submission works with new schema
- [ ] Confirm email template renders correctly
- [ ] Check database configuration references