### PR TITLE
fix (forms): Added missing schema validations for Sell Goods and Services on Beach

### DIFF
--- a/schemas/sell-goods-services-beach-park.json
+++ b/schemas/sell-goods-services-beach-park.json
@@ -61,12 +61,17 @@
           }
         },
         {
+          "name": "nationality",
+          "type": "string",
+          "label": "Nationality",
+          "required": true
+        },
+        {
           "name": "idNumber",
           "type": "string",
           "label": "National Identification (ID) Number",
           "required": false,
           "validations": {
-            "min": 2,
             "message": "ID Number must be at least 2 characters"
           }
         },


### PR DESCRIPTION
## Description

Sell goods and services schema on the backend was missing a field that the frontend schema had present.
This PR sought to resolve the discrepancy.


## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Content Update 

## Changes Made

All changes were made in `schema/sell-goods-services-beach-park.json`.

- Removed `min` check on non-required fields.
- Added backend validation for the `nationality` field.

### Notes
<!--Add notes for anything unrelated to the specified categories -->

## Testing
- [ ] Manual tests completed
- [ ] Added unit tests
- [ ] Added e2e tests

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->


## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated
