### PR TITLE
fix: Telephone validation in sell goods or services form

### DIFF
--- a/schemas/sell-goods-services-beach-park.json
+++ b/schemas/sell-goods-services-beach-park.json
@@ -89,11 +89,7 @@
           "name": "telephoneNumber",
           "type": "string",
           "label": "Telephone Number",
-          "required": true,
-          "validations": {
-            "regex": "^\\+?[0-9]{10,15}$",
-            "message": "Telephone number must be 10-15 digits"
-          }
+          "required": true
         },
         {
           "name": "addressLine1",


### PR DESCRIPTION
## Description

This PR fixes telephone number validation in the "Sell Goods or Services on Beach/Park" form. The validation regex has been removed to allow more flexible telephone number formats while maintaining the required field constraint.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made
- Remove overly restrictive telephone number validation regex from the sell goods or services form
- Keep the telephone number field as required while allowing broader input formats

### Files Changed
- **schemas/sell-goods-services-beach-park.json** - Removed regex validation pattern for telephone number field (5 lines removed, 1 line added)

### Notes
The previous validation regex (`^\\+?[0-9]{10,15}$`) was too restrictive. This change simplifies validation while keeping the field required, allowing the backend or alternative validation methods to handle more flexible telephone number formats.

## Testing
- [ ] Form submission tested with various telephone number formats
- [ ] Verify telephone field is still required
- [ ] Test form rendering with updated schema
- [ ] Validate backend handles telephone numbers correctly
- [ ] Test on all supported device sizes

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues -->

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated
- [ ] Documentation updated