### PR TITLE
Fix (Forms): JobStartPlus - 'Willing to work at night' is now optional

### DIFF
--- a/schemas/jobstart-plus-programme.json
+++ b/schemas/jobstart-plus-programme.json
@@ -480,7 +480,7 @@
           "name": "willingToWorkAtNight",
           "type": "string",
           "label": "Are you willing to work at night?",
-          "required": true,
+          "required": false,
           "validations": {
             "regex": "^(yes|no)$",
             "message": "Must select an option"


### PR DESCRIPTION
## Description

Fixes issue where even when selecting "under 18", the "Willing to work at night" was still being required on the backend, causing those selecting that value to be stuck. Fixed it by making required false;

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

- `schemas/jobstart-plus-programme.json`

### Notes
<!--Add notes for anything unrelated to the specified categories -->

## Testing
- [x] Manual tests completed
- [ ] Added unit tests
- [ ] Added e2e tests

## Related Github Issue(s)/Trello Ticket(s)

[Trello: JobStartPlus Content Update](https://trello.com/c/qmgkw5xc/372-update-jobstartplus-content)


## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated
