### PR TITLE
feat(opencrvs): use node-cache for token management with auto-retry on 401

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "handlebars": "^4.7.8",
+        "node-cache": "^5.1.2",
         "pg": "^8.16.3",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
@@ -9439,6 +9440,25 @@
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
       "dev": true
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/node-cache/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/node-emoji": {
       "version": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "handlebars": "^4.7.8",
+    "node-cache": "^5.1.2",
     "pg": "^8.16.3",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",

--- a/src/opencrvs/opencrvs-cache.service.ts
+++ b/src/opencrvs/opencrvs-cache.service.ts
@@ -1,0 +1,112 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as NodeCache from 'node-cache';
+
+export interface CachedToken {
+  accessToken: string;
+  expiresAt: number;
+}
+
+@Injectable()
+export class OpenCRVSCacheService {
+  private readonly logger = new Logger(OpenCRVSCacheService.name);
+  private readonly cache: NodeCache;
+
+  // Cache keys
+  private static readonly TOKEN_KEY = 'opencrvs_access_token';
+  private static readonly LOCATION_PREFIX = 'location:';
+
+  // Default TTLs (in seconds)
+  private static readonly LOCATION_TTL = 3600; // 1 hour for locations
+
+  constructor() {
+    this.cache = new NodeCache({
+      checkperiod: 60, // Check for expired keys every 60 seconds
+      useClones: false, // Don't clone objects for better performance
+    });
+
+    this.cache.on('expired', (key: string) => {
+      this.logger.debug(`Cache key expired: ${key}`);
+    });
+  }
+
+  /**
+   * Store access token with TTL based on expiration time
+   * Includes a 5-minute buffer before actual expiry
+   */
+  setAccessToken(accessToken: string, expiresIn: number): void {
+    // Apply 5-minute buffer to TTL
+    const bufferSeconds = 5 * 60;
+    const ttl = Math.max(expiresIn - bufferSeconds, 0);
+
+    if (ttl <= 0) {
+      this.logger.warn('Token TTL is too short, not caching');
+      return;
+    }
+
+    this.cache.set(OpenCRVSCacheService.TOKEN_KEY, accessToken, ttl);
+    this.logger.debug(`Access token cached with TTL: ${ttl}s`);
+  }
+
+  /**
+   * Get cached access token if valid
+   */
+  getAccessToken(): string | undefined {
+    return this.cache.get<string>(OpenCRVSCacheService.TOKEN_KEY);
+  }
+
+  /**
+   * Clear the access token from cache
+   */
+  clearAccessToken(): void {
+    this.cache.del(OpenCRVSCacheService.TOKEN_KEY);
+    this.logger.debug('Access token cache cleared');
+  }
+
+  /**
+   * Store location ID with TTL
+   */
+  setLocation(
+    locationType: string,
+    locationName: string,
+    locationId: string,
+    ttl: number = OpenCRVSCacheService.LOCATION_TTL,
+  ): void {
+    const key = `${OpenCRVSCacheService.LOCATION_PREFIX}${locationType}:${locationName}`;
+    this.cache.set(key, locationId, ttl);
+    this.logger.debug(`Location cached: ${key} -> ${locationId}`);
+  }
+
+  /**
+   * Get cached location ID
+   */
+  getLocation(locationType: string, locationName: string): string | undefined {
+    const key = `${OpenCRVSCacheService.LOCATION_PREFIX}${locationType}:${locationName}`;
+    return this.cache.get<string>(key);
+  }
+
+  /**
+   * Clear all location entries from cache
+   */
+  clearLocations(): void {
+    const keys = this.cache
+      .keys()
+      .filter((key) => key.startsWith(OpenCRVSCacheService.LOCATION_PREFIX));
+    keys.forEach((key) => this.cache.del(key));
+    this.logger.debug(`Cleared ${keys.length} location cache entries`);
+  }
+
+  /**
+   * Clear all cache entries
+   */
+  clearAll(): void {
+    this.cache.flushAll();
+    this.logger.debug('All cache entries cleared');
+  }
+
+  /**
+   * Get cache statistics
+   */
+  getStats(): NodeCache.Stats {
+    return this.cache.getStats();
+  }
+}

--- a/src/opencrvs/opencrvs.module.ts
+++ b/src/opencrvs/opencrvs.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { OpenCRVSService } from './opencrvs.service';
 import { BirthRegistrationMapper } from './birth-registration.mapper';
+import { OpenCRVSCacheService } from './opencrvs-cache.service';
 
 @Module({
   imports: [ConfigModule],
-  providers: [OpenCRVSService, BirthRegistrationMapper],
+  providers: [OpenCRVSCacheService, OpenCRVSService, BirthRegistrationMapper],
   exports: [OpenCRVSService, BirthRegistrationMapper],
 })
 export class OpenCRVSModule {}

--- a/src/opencrvs/opencrvs.service.ts
+++ b/src/opencrvs/opencrvs.service.ts
@@ -11,6 +11,7 @@ import {
   LocationBundle,
   LocationType,
 } from './types';
+import { OpenCRVSCacheService } from './opencrvs-cache.service';
 
 @Injectable()
 export class OpenCRVSService {
@@ -22,14 +23,10 @@ export class OpenCRVSService {
   private readonly clientId: string;
   private readonly clientSecret: string;
 
-  // Cache for access token with expiry
-  private accessToken: string | null = null;
-  private tokenExpiry: Date | null = null;
-
-  // Cache for location lookups to avoid repeated API calls
-  private readonly locationCache: Map<string, string> = new Map();
-
-  constructor(private readonly configService: ConfigService) {
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly cacheService: OpenCRVSCacheService,
+  ) {
     const isLocalhost = this.configService.get<boolean>('opencrvs.localhost');
 
     if (isLocalhost) {
@@ -64,16 +61,19 @@ export class OpenCRVSService {
 
   /**
    * Get an access token from the OpenCRVS auth service
-   * Uses caching to avoid unnecessary token requests
+   * Uses node-cache for TTL-based token management
+   * @param forceRefresh - If true, ignores cached token and fetches a new one
    */
-  async getAccessToken(): Promise<string> {
-    // Return cached token if still valid (with 5 minute buffer)
-    if (
-      this.accessToken &&
-      this.tokenExpiry &&
-      new Date() < new Date(this.tokenExpiry.getTime() - 5 * 60 * 1000)
-    ) {
-      return this.accessToken;
+  async getAccessToken(forceRefresh = false): Promise<string> {
+    // Return cached token if still valid (unless force refresh)
+    if (!forceRefresh) {
+      const cachedToken = this.cacheService.getAccessToken();
+      if (cachedToken) {
+        return cachedToken;
+      }
+    } else {
+      // Clear the cached token when forcing refresh
+      this.cacheService.clearAccessToken();
     }
 
     if (!this.clientId || !this.clientSecret) {
@@ -108,22 +108,50 @@ export class OpenCRVSService {
       throw new Error('OpenCRVS token response missing access_token');
     }
 
-    this.accessToken = data.access_token;
-
-    // Set expiry based on response or default to 1 hour
+    // Cache the token with TTL (includes 5-minute buffer)
     const expiresIn = data.expires_in ?? 3600;
-    this.tokenExpiry = new Date(Date.now() + expiresIn * 1000);
+    this.cacheService.setAccessToken(data.access_token, expiresIn);
 
     this.logger.log('OpenCRVS access token obtained successfully');
-    return this.accessToken;
+    return data.access_token;
+  }
+
+  /**
+   * Make an authenticated request with automatic token refresh on 401
+   * @param url - The URL to request
+   * @param options - Fetch options (without Authorization header)
+   * @param isRetry - Internal flag to prevent infinite retry loops
+   * @returns The fetch Response
+   */
+  private async authenticatedFetch(
+    url: string,
+    options: RequestInit = {},
+    isRetry = false,
+  ): Promise<Response> {
+    const accessToken = await this.getAccessToken();
+
+    const res = await fetch(url, {
+      ...options,
+      headers: {
+        ...options.headers,
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    // If we get a 401 and haven't retried yet, refresh token and retry once
+    if (res.status === 401 && !isRetry) {
+      this.logger.warn('Received 401, refreshing token and retrying request');
+      await this.getAccessToken(true);
+      return this.authenticatedFetch(url, options, true);
+    }
+
+    return res;
   }
 
   /**
    * Create a new birth event in OpenCRVS
    */
   async createBirthEvent(transactionId?: string): Promise<CreateEventResponse> {
-    const accessToken = await this.getAccessToken();
-
     const payload: CreateEventRequest = {
       type: 'birth',
       transactionId: transactionId ?? uuidv4(),
@@ -134,14 +162,16 @@ export class OpenCRVSService {
       `Creating birth event with transactionId: ${payload.transactionId}`,
     );
 
-    const res = await fetch(`${this.eventsBaseUrl}/api/events/events`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': 'application/json',
+    const res = await this.authenticatedFetch(
+      `${this.eventsBaseUrl}/api/events/events`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
       },
-      body: JSON.stringify(payload),
-    });
+    );
 
     if (!res.ok) {
       const errorText = await res.text();
@@ -168,8 +198,6 @@ export class OpenCRVSService {
     createdAtLocation: string,
     annotation?: Record<string, unknown>,
   ): Promise<NotifyResponse> {
-    const accessToken = await this.getAccessToken();
-
     const payload: NotifyRequest = {
       eventId,
       transactionId: uuidv4(),
@@ -181,12 +209,11 @@ export class OpenCRVSService {
 
     this.logger.log(`Notifying birth event: ${eventId}`);
 
-    const res = await fetch(
+    const res = await this.authenticatedFetch(
       `${this.eventsBaseUrl}/api/events/events/notifications`,
       {
         method: 'POST',
         headers: {
-          Authorization: `Bearer ${accessToken}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(payload),
@@ -219,10 +246,8 @@ export class OpenCRVSService {
     locationName: string,
     locationType: LocationType,
   ): Promise<string> {
-    const cacheKey = `${locationType}:${locationName}`;
-
     // Check cache first
-    const cachedId = this.locationCache.get(cacheKey);
+    const cachedId = this.cacheService.getLocation(locationType, locationName);
     if (cachedId) {
       return cachedId;
     }
@@ -254,7 +279,11 @@ export class OpenCRVSService {
     }
 
     // Cache the result
-    this.locationCache.set(cacheKey, match.resource.id);
+    this.cacheService.setLocation(
+      locationType,
+      locationName,
+      match.resource.id,
+    );
 
     this.logger.log(
       `Found location: "${locationName}" -> ${match.resource.id}`,
@@ -321,7 +350,7 @@ export class OpenCRVSService {
    * Clear the location cache (useful if locations are updated)
    */
   clearLocationCache(): void {
-    this.locationCache.clear();
+    this.cacheService.clearLocations();
     this.logger.log('Location cache cleared');
   }
 
@@ -329,8 +358,7 @@ export class OpenCRVSService {
    * Clear the access token cache (useful for testing or token refresh)
    */
   clearTokenCache(): void {
-    this.accessToken = null;
-    this.tokenExpiry = null;
+    this.cacheService.clearAccessToken();
     this.logger.log('Token cache cleared');
   }
 }


### PR DESCRIPTION
## Description

- Add OpenCRVSCacheService using node-cache for TTL-based caching
- Implement automatic token refresh with 5-minute buffer before expiry
- Add authenticatedFetch helper that retries once on 401 expired token
- Replace manual token/location caching with node-cache service


## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

<!--List the files changed and why -->

### Notes
<!--Add notes for anything unrelated to the specified categories -->

## Testing
- [ ] Manual tests completed
- [ ] Added unit tests
- [ ] Added e2e tests

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->


## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated
