### PR TITLE
fix: adjust token expiration time from 1 hour to 10 minutes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "handlebars": "^4.7.8",
+        "jwt-decode": "^4.0.0",
         "node-cache": "^5.1.2",
         "pg": "^8.16.3",
         "reflect-metadata": "^0.1.13",
@@ -9049,6 +9050,15 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "class-validator": "^0.14.2",
     "handlebars": "^4.7.8",
     "node-cache": "^5.1.2",
+    "jwt-decode": "^4.0.0",
     "pg": "^8.16.3",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",

--- a/src/opencrvs/opencrvs.service.ts
+++ b/src/opencrvs/opencrvs.service.ts
@@ -109,7 +109,7 @@ export class OpenCRVSService {
     }
 
     // Cache the token with TTL (includes 5-minute buffer)
-    const expiresIn = data.expires_in ?? 3600;
+    const expiresIn = data.expires_in ?? 600;
     this.cacheService.setAccessToken(data.access_token, expiresIn);
 
     this.logger.log('OpenCRVS access token obtained successfully');

--- a/src/opencrvs/opencrvs.service.ts
+++ b/src/opencrvs/opencrvs.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { jwtDecode } from 'jwt-decode';
 import { v4 as uuidv4 } from 'uuid';
 import {
   TokenResponse,
@@ -12,6 +13,8 @@ import {
   LocationType,
 } from './types';
 import { OpenCRVSCacheService } from './opencrvs-cache.service';
+
+const TOKEN_EXPIRY_FALLBACK_SECONDS = 10 * 60; // 10 minutes
 
 @Injectable()
 export class OpenCRVSService {
@@ -108,8 +111,10 @@ export class OpenCRVSService {
       throw new Error('OpenCRVS token response missing access_token');
     }
 
-    // Cache the token with TTL (includes 5-minute buffer)
-    const expiresIn = data.expires_in ?? 600;
+    const payload = jwtDecode<{ exp?: number }>(data.access_token);
+    const expiresIn = payload.exp
+      ? payload.exp - Math.floor(Date.now() / 1000)
+      : TOKEN_EXPIRY_FALLBACK_SECONDS;
     this.cacheService.setAccessToken(data.access_token, expiresIn);
 
     this.logger.log('OpenCRVS access token obtained successfully');

--- a/src/opencrvs/opencrvs.service.ts
+++ b/src/opencrvs/opencrvs.service.ts
@@ -112,10 +112,18 @@ export class OpenCRVSService {
     }
 
     const payload = jwtDecode<{ exp?: number }>(data.access_token);
-    const expiresIn = payload.exp
-      ? payload.exp - Math.floor(Date.now() / 1000)
-      : TOKEN_EXPIRY_FALLBACK_SECONDS;
-    this.cacheService.setAccessToken(data.access_token, expiresIn);
+
+    const currentTimeSec = Math.floor(Date.now() / 1000);
+
+    // Default fallback in case the token has no `exp`
+    let secondsUntilExpiry = TOKEN_EXPIRY_FALLBACK_SECONDS;
+
+    // If the JWT has an `exp`, calculate how many seconds remain until it expires
+    if (payload.exp) {
+      secondsUntilExpiry = payload.exp - currentTimeSec;
+    }
+
+    this.cacheService.setAccessToken(data.access_token, secondsUntilExpiry);
 
     this.logger.log('OpenCRVS access token obtained successfully');
     return data.access_token;


### PR DESCRIPTION
## Description
Adjusted the token expiry from 1 hour time to 10 minutes as per default settings

## Type of Change
- [ X ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made
OpenCRVS token expiry time set to 10 minutes 

## Testing
- [ X ] Manual tests completed
- [ ] Added unit tests
- [ ] Added e2e tests

## Checklist
- [ X ] Code follows project style guidelines
- [ X ] Self-review completed
- [ ] Documentation updated
