### PR TITLE
Quickfix (Sell Goods): Fixed issue where `min` was making an optional field required

### DIFF
--- a/schemas/sell-goods-services-beach-park.json
+++ b/schemas/sell-goods-services-beach-park.json
@@ -184,7 +184,6 @@
             "value": "imported"
           },
           "validations": {
-            "min": 2,
             "max": 100,
             "message": "Location must be at least 2 characters"
           }


### PR DESCRIPTION
## Description

Fixed issue where `min` validation was forcing `Manufacturing Location` to be seen as required although it isn'tt.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

- schemas/sell-goods-services-beach-park.json

### Notes
<!--Add notes for anything unrelated to the specified categories -->

## Testing
- [x] Manual tests completed
- [ ] Added unit tests
- [ ] Added e2e tests

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->


## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated
