### PR TITLE
RELEASE: OpenCRVS cache service dependency injection

### DIFF
--- a/src/opencrvs/opencrvs.service.ts
+++ b/src/opencrvs/opencrvs.service.ts
@@ -26,14 +26,10 @@ export class OpenCRVSService {
   private readonly clientId: string;
   private readonly clientSecret: string;
 
-  // Cache for access token with expiry
-  private accessToken: string | null = null;
-  private tokenExpiry: Date | null = null;
-
-  // Cache for location lookups to avoid repeated API calls
-  private readonly locationCache: Map<string, string> = new Map();
-
-  constructor(private readonly configService: ConfigService) {
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly cacheService: OpenCRVSCacheService,
+  ) {
     this.authBaseUrl = this.configService.get<string>(
       'opencrvs.authBaseUrl',
       'https://auth.barbados-qa.opencrvs.org',


### PR DESCRIPTION
## Description

This PR merges the fix from `develop` into `production` to restore the missing cache service dependency in the OpenCRVS service constructor, which was preventing the production build from running.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

| File | Changes |
|------|---------|
| `src/opencrvs/opencrvs.service.ts` | Re-added `cacheService` dependency injection to the constructor |

### Root Cause
The cache service dependency was accidentally removed from the OpenCRVS service constructor, causing a missing dependency error that blocked the production deployment.

## Testing
- [x] Manual tests completed
- [ ] Added unit tests
- [ ] Added e2e tests

## Related Github Issue(s)/Trello Ticket(s)
- PR #92: Refactor: Update OpenCRVSService Constructor to Include CacheService Dependency

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated