### PR TITLE
fix (forms): display correct payment amount based on provided date of birth

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,9 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    },
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],

--- a/schemas/get-birth-certificate.json
+++ b/schemas/get-birth-certificate.json
@@ -489,7 +489,7 @@
 				"provider": "ezpay",
 				"department": "oag_registration",
 				"paymentCode": "{{db:get-birth-certificate:payment_code}}",
-				"amount": "{{formData.order.numberOfCopies * db:get-birth-certificate:payment_amount}}",
+				"amount": "{{formData.order.numberOfCopies * ageDbSelect(formData.birthDetails.dateOfBirth, 60, db:get-birth-certificate:alternate_payment_amount, db:get-birth-certificate:payment_amount)}}",
 				"description": "Birth Certificate Processing Fee (per copy)",
 				"required": true,
 				"timing": "after_validation",

--- a/src/forms/expression-resolver.service.spec.ts
+++ b/src/forms/expression-resolver.service.spec.ts
@@ -618,6 +618,102 @@ describe('ExpressionResolverService', () => {
     });
   });
 
+  describe('resolveExpression - ageDbSelect Conditional DB Lookup', () => {
+    const ALTERNATE_PAYMENT_AMOUNT = '15';
+    const STANDARD_PAYMENT_AMOUNT = '25';
+
+    beforeEach(() => {
+      mockConfigRepository.findOne.mockImplementation(async (options: any) => {
+        const key = options.where.key;
+        if (key === 'alternate_payment_amount') {
+          return createMockFormConfig(
+            '1',
+            'get-birth-certificate',
+            'alternate_payment_amount',
+            ALTERNATE_PAYMENT_AMOUNT,
+          );
+        }
+        if (key === 'payment_amount') {
+          return createMockFormConfig(
+            '2',
+            'get-birth-certificate',
+            'payment_amount',
+            STANDARD_PAYMENT_AMOUNT,
+          );
+        }
+        return null;
+      });
+    });
+
+    it('should use alternate_payment_amount when dateOfBirth is 60+ years ago', async () => {
+      const context: ExpressionContext = {
+        formId: 'get-birth-certificate',
+        configRepository: mockConfigRepository,
+        formData: {
+          birthDetails: { dateOfBirth: '1960-06-15' },
+          order: { numberOfCopies: 2 },
+        },
+      };
+
+      const result = await service.resolveExpression(
+        '{{formData.order.numberOfCopies * ageDbSelect(formData.birthDetails.dateOfBirth, 60, db:get-birth-certificate:alternate_payment_amount, db:get-birth-certificate:payment_amount)}}',
+        context,
+      );
+      expect(result).toBe(2 * parseInt(ALTERNATE_PAYMENT_AMOUNT, 10));
+    });
+
+    it('should use payment_amount when dateOfBirth is less than 60 years ago', async () => {
+      const context: ExpressionContext = {
+        formId: 'get-birth-certificate',
+        configRepository: mockConfigRepository,
+        formData: {
+          birthDetails: { dateOfBirth: '2000-06-15' },
+          order: { numberOfCopies: 3 },
+        },
+      };
+
+      const result = await service.resolveExpression(
+        '{{formData.order.numberOfCopies * ageDbSelect(formData.birthDetails.dateOfBirth, 60, db:get-birth-certificate:alternate_payment_amount, db:get-birth-certificate:payment_amount)}}',
+        context,
+      );
+      expect(result).toBe(3 * parseInt(STANDARD_PAYMENT_AMOUNT, 10));
+    });
+
+    it('should use payment_amount when dateOfBirth is missing', async () => {
+      const context: ExpressionContext = {
+        formId: 'get-birth-certificate',
+        configRepository: mockConfigRepository,
+        formData: {
+          birthDetails: {},
+          order: { numberOfCopies: 1 },
+        },
+      };
+
+      const result = await service.resolveExpression(
+        '{{formData.order.numberOfCopies * ageDbSelect(formData.birthDetails.dateOfBirth, 60, db:get-birth-certificate:alternate_payment_amount, db:get-birth-certificate:payment_amount)}}',
+        context,
+      );
+      expect(result).toBe(1 * parseInt(STANDARD_PAYMENT_AMOUNT, 10));
+    });
+
+    it('should use payment_amount when dateOfBirth is an invalid date string', async () => {
+      const context: ExpressionContext = {
+        formId: 'get-birth-certificate',
+        configRepository: mockConfigRepository,
+        formData: {
+          birthDetails: { dateOfBirth: 'not-a-date' },
+          order: { numberOfCopies: 1 },
+        },
+      };
+
+      const result = await service.resolveExpression(
+        '{{formData.order.numberOfCopies * ageDbSelect(formData.birthDetails.dateOfBirth, 60, db:get-birth-certificate:alternate_payment_amount, db:get-birth-certificate:payment_amount)}}',
+        context,
+      );
+      expect(result).toBe(1 * parseInt(STANDARD_PAYMENT_AMOUNT, 10));
+    });
+  });
+
   describe('Edge Cases', () => {
     it('should handle empty formData', async () => {
       const context: ExpressionContext = {

--- a/src/forms/expression-resolver.service.ts
+++ b/src/forms/expression-resolver.service.ts
@@ -23,6 +23,8 @@ export class ExpressionResolverService {
    * - Form data references: {{formData.path}}
    * - Values from constant data source: {{constants:KVPair:key}}
    * - Mathematical expressions: {{formData.field * db:form-id:amount}}
+   * - Age-conditional DB selects: ageDbSelect(formData.path, minAge, db:formId:trueKey, db:formId:falseKey)
+   *   Resolves to trueKey value when the date at formData.path is >= minAge years old, falseKey otherwise
    * - Simple values: direct strings or numbers
    * - Multiple expressions in a string: "Hello {{formData.name}} from {{formData.city}}"
    */
@@ -98,7 +100,13 @@ export class ExpressionResolverService {
 
     let mathExpression = match[1];
 
-    // Replace database references first
+    // Resolve age-conditional DB selects before other replacements
+    mathExpression = await this.resolveAgeDbSelectExpressions(
+      mathExpression,
+      context,
+    );
+
+    // Replace database references
     mathExpression = await this.replaceDatabaseReferences(
       mathExpression,
       context,
@@ -109,6 +117,72 @@ export class ExpressionResolverService {
 
     // Evaluate the mathematical expression
     return this.evaluateMathExpression(mathExpression);
+  }
+
+  /**
+   * Resolve ageDbSelect(formData.path, minAge, db:formId:trueKey, db:formId:falseKey) expressions.
+   *
+   * When the date at formData.path is >= minAge years old, the trueKey DB value is used.
+   * When the date is missing, invalid, or < minAge years old, the falseKey DB value is used.
+   */
+  private async resolveAgeDbSelectExpressions(
+    expression: string,
+    context: ExpressionContext,
+  ): Promise<string> {
+    const pattern =
+      /ageDbSelect\(formData\.([a-zA-Z0-9_.]+),\s*(\d+),\s*(db:[^,\s]+),\s*(db:[^)\s]+)\)/g;
+
+    let result = expression;
+    const matches = [...expression.matchAll(pattern)];
+
+    for (const match of matches) {
+      const [fullMatch, dateFieldPath, minAgeStr, trueDbRef, falseDbRef] =
+        match;
+
+      const dateValue = context.formData
+        ? this.getNestedValue(context.formData, dateFieldPath)
+        : undefined;
+
+      const ageInYears =
+        dateValue ? this.calculateAgeInYears(String(dateValue)) : NaN;
+
+      // NaN comparisons are always false, so missing/invalid dates fall through to falseDbRef
+      const selectedDbRef =
+        ageInYears >= parseInt(minAgeStr, 10) ? trueDbRef : falseDbRef;
+
+      const resolved = await this.replaceDatabaseReferences(
+        selectedDbRef,
+        context,
+      );
+      result = result.replace(fullMatch, resolved);
+    }
+
+    return result;
+  }
+
+  /**
+   * Calculate age in whole years from an ISO date string (YYYY-MM-DD).
+   * Returns NaN when the input cannot be parsed as a valid date.
+   */
+  private calculateAgeInYears(dateString: string): number {
+    const birthDate = new Date(dateString);
+
+    if (isNaN(birthDate.getTime())) {
+      return NaN;
+    }
+
+    const today = new Date();
+    let age = today.getFullYear() - birthDate.getFullYear();
+    const monthDiff = today.getMonth() - birthDate.getMonth();
+
+    if (
+      monthDiff < 0 ||
+      (monthDiff === 0 && today.getDate() < birthDate.getDate())
+    ) {
+      age--;
+    }
+
+    return age;
   }
 
   /**


### PR DESCRIPTION
## Description
Display `alternate_payment_amount` if the date of birth of the person being applied for is over 60 years old

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

1. Add new expression resolver for determining if age is over 60 years or not
2. Update tests for expression resolver
3. Update birth-certificate schema's payment (EzPay) provider to calculate amount conditionally based on result from `ageDbSelect` resolver

### Notes
<!--Add notes for anything unrelated to the specified categories -->

## Testing
- [x] Manual tests completed
- [x] Added unit tests
- [ ] Added e2e tests

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->
#104 

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated
