### PR TITLE
Fix (Form): Incorrect validation on "manufacturingLocation" field in Sell Goods

### DIFF
--- a/schemas/sell-goods-services-beach-park.json
+++ b/schemas/sell-goods-services-beach-park.json
@@ -184,7 +184,6 @@
             "value": "imported"
           },
           "validations": {
-            "min": 2,
             "max": 100,
             "message": "Location must be at least 2 characters"
           }


### PR DESCRIPTION
## Description

Fixed issue where manufacturingLocation, was being forced to be validated even though it was not required

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

- `schemas/sell-goods-services-beach-park.json`: Removed the `min` validation

### Notes

This is a bigger validation issue that needs to be fixed otherwise, with how `required` and `min` are handled.

## Testing
- [x] Manual tests completed
- [ ] Added unit tests
- [ ] Added e2e tests

## Related Github Issue(s)/Trello Ticket(s)

Address Issue https://github.com/govtech-bb/frontend-alpha/issues/455 (On the frontend)


## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated
