### PR TITLE
Fix (Service): Fixed how validation for non-required string fields are handled

### DIFF
--- a/schemas/sell-goods-services-beach-park.json
+++ b/schemas/sell-goods-services-beach-park.json
@@ -184,6 +184,7 @@
             "value": "imported"
           },
           "validations": {
+            "min": 2,
             "max": 100,
             "message": "Location must be at least 2 characters"
           }

--- a/src/validation/schema-builder.service.ts
+++ b/src/validation/schema-builder.service.ts
@@ -398,7 +398,18 @@ export class SchemaBuilderService {
     fieldType: string,
     required = true,
   ): any {
-    // Min/Max for strings
+    // Skip all validations for optional string fields with no value provided
+    if (fieldType === 'string' && !required) {
+      return schema.refine(
+        (val: string) =>
+          !val ||
+          val.length === 0 ||
+          this.validateStringValue(val, validations),
+        { message: validations.message || 'Validation failed' },
+      );
+    }
+
+    // Min/Max for strings (required fields)
     if (
       fieldType === 'string' &&
       (validations.min !== undefined || validations.max !== undefined)
@@ -466,6 +477,29 @@ export class SchemaBuilderService {
     }
 
     return schema;
+  }
+
+  private validateStringValue(
+    val: string,
+    validations: FieldValidation,
+  ): boolean {
+    if (validations.min !== undefined && val.length < validations.min) {
+      return false;
+    }
+    if (validations.max !== undefined && val.length > validations.max) {
+      return false;
+    }
+    if (validations.regex) {
+      try {
+        const regex = new RegExp(validations.regex);
+        if (!regex.test(val)) {
+          return false;
+        }
+      } catch {
+        return false;
+      }
+    }
+    return true;
   }
 
   private buildPrimitiveSchema(type: string): any {


### PR DESCRIPTION
## Description

Fields that have a min validation (for content length), but have required=false, will no longer trigger validation errors for minimum content length.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

- `src/validation/schema-builder.service.ts`

### Notes

For this, we add a helper method to the applyValidations method, which will check if the field is a string, empty, and not required.

## Testing
- [x] Manual tests completed
- [ ] Added unit tests
- [ ] Added e2e tests

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->


## Checklist
- [x] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated
