### PR TITLE
Fix:birth certificate required "birthdetails"

### DIFF
--- a/schemas/get-birth-certificate.json
+++ b/schemas/get-birth-certificate.json
@@ -269,14 +269,12 @@
         {
           "name": "dateOfBirth",
           "type": "date",
-          "label": "Date of birth",
-          "required": false
+          "label": "Date of birth"
         },
         {
           "name": "placeOfBirth",
           "type": "string",
           "label": "Place of birth",
-          "required": false,
           "validations": {
             "min": 2,
             "max": 200,

--- a/schemas/get-birth-certificate.json
+++ b/schemas/get-birth-certificate.json
@@ -322,7 +322,7 @@
               "name": "middleName",
               "type": "string",
               "label": "Father's middle name",
-              "required": true,
+              "required": false,
               "validations": {
                 "max": 100,
                 "message": "Middle name is required"
@@ -361,7 +361,7 @@
               "name": "middleName",
               "type": "string",
               "label": "Mother's middle name",
-              "required": true,
+              "required": false,
               "validations": {
                 "max": 100,
                 "message": "Middle name is required"

--- a/schemas/get-birth-certificate.json
+++ b/schemas/get-birth-certificate.json
@@ -265,7 +265,6 @@
     {
       "name": "birthDetails",
       "type": "object",
-      "required": false,
       "fields": [
         {
           "name": "dateOfBirth",
@@ -482,39 +481,39 @@
       ]
     }
   ],
-	"processors": [
-		{
-			"type": "payment",
-			"config": {
-				"provider": "ezpay",
-				"department": "oag_registration",
-				"paymentCode": "{{db:get-birth-certificate:payment_code}}",
-				"amount": "{{formData.order.numberOfCopies * ageDbSelect(formData.birthDetails.dateOfBirth, 60, db:get-birth-certificate:alternate_payment_amount, db:get-birth-certificate:payment_amount)}}",
-				"description": "Birth Certificate Processing Fee (per copy)",
-				"required": true,
-				"timing": "after_validation",
-				"responseData": {
-					"include": ["order.numberOfCopies"]
-				}
-			}
-		},
-		{
-			"type": "email",
-			"config": {
-				"to": "{{db:get-birth-certificate:admin_email}}",
-				"subject": "New Birth Certificate Application - {{formData.applicant.firstName}} {{formData.applicant.lastName}}",
-				"template": "birth-certificate",
-				"recipientType": "admin"
-			}
-		},
-		{
-			"type": "email",
-			"config": {
-				"to": "{{formData.applicant.email}}",
-				"subject": "Birth Certificate - Submission Received",
-				"template": "birth-certificate-receipt",
-				"recipientType": "user"
-			}
-		}
-	]
+  "processors": [
+    {
+      "type": "payment",
+      "config": {
+        "provider": "ezpay",
+        "department": "oag_registration",
+        "paymentCode": "{{db:get-birth-certificate:payment_code}}",
+        "amount": "{{formData.order.numberOfCopies * ageDbSelect(formData.birthDetails.dateOfBirth, 60, db:get-birth-certificate:alternate_payment_amount, db:get-birth-certificate:payment_amount)}}",
+        "description": "Birth Certificate Processing Fee (per copy)",
+        "required": true,
+        "timing": "after_validation",
+        "responseData": {
+          "include": ["order.numberOfCopies"]
+        }
+      }
+    },
+    {
+      "type": "email",
+      "config": {
+        "to": "{{db:get-birth-certificate:admin_email}}",
+        "subject": "New Birth Certificate Application - {{formData.applicant.firstName}} {{formData.applicant.lastName}}",
+        "template": "birth-certificate",
+        "recipientType": "admin"
+      }
+    },
+    {
+      "type": "email",
+      "config": {
+        "to": "{{formData.applicant.email}}",
+        "subject": "Birth Certificate - Submission Received",
+        "template": "birth-certificate-receipt",
+        "recipientType": "user"
+      }
+    }
+  ]
 }

--- a/schemas/get-birth-certificate.json
+++ b/schemas/get-birth-certificate.json
@@ -300,18 +300,18 @@
     {
       "name": "parents",
       "type": "object",
-      "required": false,
+      "required": true,
       "fields": [
         {
           "name": "father",
           "type": "object",
-          "required": false,
+          "required": true,
           "fields": [
             {
               "name": "firstName",
               "type": "string",
               "label": "Father's first name",
-              "required": false,
+              "required": true,
               "validations": {
                 "min": 1,
                 "max": 100,
@@ -322,7 +322,7 @@
               "name": "middleName",
               "type": "string",
               "label": "Father's middle name",
-              "required": false,
+              "required": true,
               "validations": {
                 "max": 100,
                 "message": "Middle name is required"
@@ -332,7 +332,7 @@
               "name": "lastName",
               "type": "string",
               "label": "Father's last name",
-              "required": false,
+              "required": true,
               "validations": {
                 "min": 1,
                 "max": 100,
@@ -344,13 +344,13 @@
         {
           "name": "mother",
           "type": "object",
-          "required": false,
+          "required": true,
           "fields": [
             {
               "name": "firstName",
               "type": "string",
               "label": "Mother's first name",
-              "required": false,
+              "required": true,
               "validations": {
                 "min": 1,
                 "max": 100,
@@ -361,7 +361,7 @@
               "name": "middleName",
               "type": "string",
               "label": "Mother's middle name",
-              "required": false,
+              "required": true,
               "validations": {
                 "max": 100,
                 "message": "Middle name is required"
@@ -371,7 +371,7 @@
               "name": "lastName",
               "type": "string",
               "label": "Mother's last name",
-              "required": false,
+              "required": true,
               "validations": {
                 "min": 1,
                 "max": 100,
@@ -382,87 +382,7 @@
         }
       ]
     },
-    {
-      "name": "parentsOther",
-      "type": "object",
-      "required": false,
-      "fields": [
-        {
-          "name": "father",
-          "type": "object",
-          "required": false,
-          "fields": [
-            {
-              "name": "firstName",
-              "type": "string",
-              "label": "Father's first name",
-              "required": false,
-              "validations": {
-                "max": 100,
-                "message": "First name is required"
-              }
-            },
-            {
-              "name": "middleName",
-              "type": "string",
-              "label": "Father's middle name",
-              "required": false,
-              "validations": {
-                "max": 100,
-                "message": "Middle name is required"
-              }
-            },
-            {
-              "name": "lastName",
-              "type": "string",
-              "label": "Father's last name",
-              "required": false,
-              "validations": {
-                "max": 100,
-                "message": "Last name is required"
-              }
-            }
-          ]
-        },
-        {
-          "name": "mother",
-          "type": "object",
-          "required": false,
-          "fields": [
-            {
-              "name": "firstName",
-              "type": "string",
-              "label": "Mother's first name",
-              "required": false,
-              "validations": {
-                "max": 100,
-                "message": "First name is required"
-              }
-            },
-            {
-              "name": "middleName",
-              "type": "string",
-              "label": "Mother's middle name",
-              "required": false,
-              "validations": {
-                "max": 100,
-                "message": "Middle name is required"
-              }
-            },
-            {
-              "name": "lastName",
-              "type": "string",
-              "label": "Mother's last name",
-              "required": false,
-              "validations": {
-                "max": 100,
-                "message": "Last name is required"
-              }
-            }
-          ]
-        }
-      ]
-    },
+
     {
       "name": "order",
       "type": "object",

--- a/schemas/get-birth-certificate.json
+++ b/schemas/get-birth-certificate.json
@@ -265,16 +265,19 @@
     {
       "name": "birthDetails",
       "type": "object",
+      "required": true,
       "fields": [
         {
           "name": "dateOfBirth",
           "type": "date",
-          "label": "Date of birth"
+          "label": "Date of birth",
+          "required": true
         },
         {
           "name": "placeOfBirth",
           "type": "string",
           "label": "Place of birth",
+          "required": true,
           "validations": {
             "min": 2,
             "max": 200,
@@ -285,7 +288,7 @@
           "name": "placeOfBaptism",
           "type": "string",
           "label": "Place of baptism",
-          "required": false,
+          "required": true,
           "validations": {
             "min": 2,
             "max": 200,


### PR DESCRIPTION
## Description
Update "Get a birth certificate" form schema so that the 'birthDetails' object is required

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

<!--List the files changed and why -->
Update `get-birth-certificate.json` schema

### Notes
<!--Add notes for anything unrelated to the specified categories -->

## Testing
- [ ] Manual tests completed
- [ ] Added unit tests
- [ ] Added e2e tests

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->
https://trello.com/c/U9RjtQB5/405-add-missing-conditional-step-to-get-birth-certificate-form

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated
