### PR TITLE
feat: add auth and feature flagging services

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,25 @@
 {
 	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	"[javascript]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"[typescript]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"[javascriptreact]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"[typescriptreact]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"[json]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"[jsonc]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
 	"editor.formatOnSave": true,
 	"editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
-  }
+		"source.fixAll.eslint": "explicit"
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@nestjs/platform-express": "^9.0.0",
         "@nestjs/schedule": "^3.0.4",
         "@nestjs/typeorm": "^11.0.0",
+        "aws-jwt-verify": "^5.1.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "handlebars": "^4.7.8",
@@ -6378,6 +6379,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/aws-jwt-verify": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/aws-jwt-verify/-/aws-jwt-verify-5.1.1.tgz",
+      "integrity": "sha512-j6whGdGJmQ27agk4ijY8RPv6itb8JLb7SCJ86fEnneTcSBrpxuwL8kLq6y5WVH95aIknyAloEqAsaOLS1J8ITQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/babel-jest": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@nestjs/platform-express": "^9.0.0",
     "@nestjs/schedule": "^3.0.4",
     "@nestjs/typeorm": "^11.0.0",
+    "aws-jwt-verify": "^5.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "handlebars": "^4.7.8",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { ProcessorsModule } from './processors/processors.module';
 import { EmailModule } from './email/email.module';
 import { FileModule } from './file/file.module';
 import { MetricsModule } from './metrics/metrics.module';
+import { AuthModule } from './auth/auth.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { MetricsModule } from './metrics/metrics.module';
     EmailModule,
     FileModule,
     MetricsModule,
+    AuthModule,
   ],
   controllers: [],
   providers: [],

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { CognitoGuard } from './cognito.guard';
+
+@Module({
+  providers: [CognitoGuard],
+  exports: [CognitoGuard],
+})
+export class AuthModule {}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { CognitoGuard } from './cognito.guard';
 
 @Module({
+  imports: [ConfigModule],
   providers: [CognitoGuard],
   exports: [CognitoGuard],
 })

--- a/src/auth/cognito.guard.ts
+++ b/src/auth/cognito.guard.ts
@@ -5,7 +5,7 @@ import {
   Logger,
   UnauthorizedException,
 } from '@nestjs/common';
-import type { ConfigService } from '@nestjs/config';
+import { ConfigService } from '@nestjs/config';
 import { CognitoJwtVerifier } from 'aws-jwt-verify';
 import type { Request } from 'express';
 

--- a/src/auth/cognito.guard.ts
+++ b/src/auth/cognito.guard.ts
@@ -1,0 +1,73 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type { ConfigService } from '@nestjs/config';
+import { CognitoJwtVerifier } from 'aws-jwt-verify';
+import type { Request } from 'express';
+
+/**
+ * Validates Cognito-issued JWTs on incoming requests.
+ *
+ * Reads the Bearer token from the Authorization header, verifies its
+ * signature against the User Pool's JWKS endpoint, and confirms the
+ * token was issued for the configured app client. The JWKS response
+ * is cached by aws-jwt-verify so repeated calls do not hit the network.
+ *
+ * Apply this guard only to write endpoints — read endpoints remain open
+ * so the alpha-preview frontend can call them without user context.
+ */
+@Injectable()
+export class CognitoGuard implements CanActivate {
+  private readonly logger = new Logger(CognitoGuard.name);
+
+  private readonly verifier: ReturnType<typeof CognitoJwtVerifier.create>;
+
+  constructor(private readonly configService: ConfigService) {
+    const userPoolId = this.configService.get<string>('cognito.userPoolId');
+    const clientId = this.configService.get<string>('cognito.clientId');
+
+    if (!userPoolId || !clientId) {
+      throw new Error(
+        'AWS_COGNITO_USER_POOL_ID and AWS_COGNITO_CLIENT_ID must be set to use CognitoGuard',
+      );
+    }
+
+    this.verifier = CognitoJwtVerifier.create({
+      userPoolId,
+      clientId,
+      tokenUse: 'access',
+    });
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const token = this.extractBearerToken(request);
+
+    if (!token) {
+      throw new UnauthorizedException('Missing Authorization header');
+    }
+
+    try {
+      const payload = await this.verifier.verify(token);
+      // Attach decoded claims so downstream handlers can access them if needed
+      (request as Request & { cognitoClaims: typeof payload }).cognitoClaims =
+        payload;
+      return true;
+    } catch (err) {
+      this.logger.warn(`JWT verification failed: ${(err as Error).message}`);
+      throw new UnauthorizedException('Invalid or expired token');
+    }
+  }
+
+  private extractBearerToken(request: Request): string | null {
+    const authHeader = request.headers.authorization;
+    if (!authHeader?.startsWith('Bearer ')) {
+      return null;
+    }
+    return authHeader.slice(7);
+  }
+}

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -86,4 +86,8 @@ export default () => ({
     namespace: process.env.METRICS_NAMESPACE || 'FormsProcessor/Submissions',
     environment: process.env.NODE_ENV || 'development',
   },
+  cognito: {
+    userPoolId: process.env.AWS_COGNITO_USER_POOL_ID,
+    clientId: process.env.AWS_COGNITO_CLIENT_ID,
+  },
 });

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { FormConfig } from './entities';
+import { FormConfig, ServiceAccess } from './entities';
 import { dataSource } from './datasource';
 
 @Module({
@@ -11,7 +11,7 @@ import { dataSource } from './datasource';
       },
       dataSourceFactory: () => dataSource.initialize(),
     }),
-    TypeOrmModule.forFeature([FormConfig]),
+    TypeOrmModule.forFeature([FormConfig, ServiceAccess]),
   ],
   exports: [TypeOrmModule],
 })

--- a/src/database/entities/index.ts
+++ b/src/database/entities/index.ts
@@ -2,3 +2,4 @@ export * from './form-config.entity';
 export * from './payment.entity';
 export * from './payment-transaction.entity';
 export * from './form-submission-payment.entity';
+export * from './service-access.entity';

--- a/src/database/entities/service-access.entity.ts
+++ b/src/database/entities/service-access.entity.ts
@@ -1,0 +1,47 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+/**
+ * Stores protection config at two levels of granularity:
+ *
+ *   subpageSlug = ''      → service-level row; controls category listing visibility
+ *   subpageSlug = 'form'  → subpage-level row; controls access to that specific subpage
+ *
+ * Absence of a row defaults to unprotected (fail open).
+ */
+@Entity('service_access_configs')
+@Index(['serviceSlug', 'subpageSlug'], { unique: true })
+export class ServiceAccess {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** Matches the page slug in the frontend content directory (e.g. "register-a-birth") */
+  @Column({ name: 'service_slug', type: 'varchar', length: 255 })
+  serviceSlug: string;
+
+  /**
+   * The subpage slug this row applies to (e.g. "start", "form").
+   * Empty string is the sentinel for a service-level row.
+   */
+  @Column({ name: 'subpage_slug', type: 'varchar', length: 255, default: '' })
+  subpageSlug: string;
+
+  @Column({ name: 'is_protected', default: false })
+  isProtected: boolean;
+
+  /** Optional note explaining why this entry is protected */
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/src/database/migrations/1769600000000-CreateServiceAccessConfigsTable.ts
+++ b/src/database/migrations/1769600000000-CreateServiceAccessConfigsTable.ts
@@ -1,0 +1,76 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateServiceAccessConfigsTable1769600000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'service_access_configs',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'service_slug',
+            type: 'varchar',
+            length: '255',
+          },
+          {
+            /**
+             * The subpage slug this row applies to (e.g. "start", "form").
+             * Empty string is the sentinel for a service-level row that controls
+             * category listing visibility.
+             */
+            name: 'subpage_slug',
+            type: 'varchar',
+            length: '255',
+            default: "''",
+          },
+          {
+            name: 'is_protected',
+            type: 'boolean',
+            default: false,
+          },
+          {
+            name: 'description',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'service_access_configs',
+      new TableIndex({
+        name: 'IDX_SERVICE_ACCESS_SLUG_SUBPAGE',
+        columnNames: ['service_slug', 'subpage_slug'],
+        isUnique: true,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex(
+      'service_access_configs',
+      'IDX_SERVICE_ACCESS_SLUG_SUBPAGE',
+    );
+    await queryRunner.dropTable('service_access_configs');
+  }
+}

--- a/src/email/email.service.ts
+++ b/src/email/email.service.ts
@@ -57,61 +57,64 @@ export class EmailService {
 
   private registerHandlebarsHelpers(): void {
     // Equality helper
-    Handlebars.registerHelper('eq', function(a, b) {
+    Handlebars.registerHelper('eq', function (a, b) {
       return a === b;
     });
 
     // Not equal helper
-    Handlebars.registerHelper('ne', function(a, b) {
+    Handlebars.registerHelper('ne', function (a, b) {
       return a !== b;
     });
 
     // Greater than helper
-    Handlebars.registerHelper('gt', function(a, b) {
+    Handlebars.registerHelper('gt', function (a, b) {
       return a > b;
     });
 
     // Less than helper
-    Handlebars.registerHelper('lt', function(a, b) {
+    Handlebars.registerHelper('lt', function (a, b) {
       return a < b;
     });
 
     // Greater than or equal helper
-    Handlebars.registerHelper('gte', function(a, b) {
+    Handlebars.registerHelper('gte', function (a, b) {
       return a >= b;
     });
 
     // Less than or equal helper
-    Handlebars.registerHelper('lte', function(a, b) {
+    Handlebars.registerHelper('lte', function (a, b) {
       return a <= b;
     });
 
     // Logical AND helper
-    Handlebars.registerHelper('and', function(...args) {
+    Handlebars.registerHelper('and', function (...args) {
       // Remove the last argument which is the options object
       const values = args.slice(0, -1);
       return values.every((val) => !!val);
     });
 
     // Logical OR helper
-    Handlebars.registerHelper('or', function(...args) {
+    Handlebars.registerHelper('or', function (...args) {
       // Remove the last argument which is the options object
       const values = args.slice(0, -1);
       return values.some((val) => !!val);
     });
 
-    Handlebars.registerHelper('today', function(...args) {
+    Handlebars.registerHelper('today', function (...args) {
       const currentDate = new Date();
       return currentDate.toDateString();
     });
 
-    Handlebars.registerHelper('titleCase', function(...args) {
+    Handlebars.registerHelper('titleCase', function (...args) {
       const values = args.slice(0, -1);
       const titled = values
-        .filter(v => typeof v === 'string')
-        .map(str => str.toLowerCase()
-          .replace(/\b\w/g, (char: string) => char.toUpperCase()))
-        .join(" ");
+        .filter((v) => typeof v === 'string')
+        .map((str) =>
+          str
+            .toLowerCase()
+            .replace(/\b\w/g, (char: string) => char.toUpperCase()),
+        )
+        .join(' ');
 
       return Handlebars.escapeExpression(titled);
     });

--- a/src/forms/dto/feature-flag.dto.ts
+++ b/src/forms/dto/feature-flag.dto.ts
@@ -1,0 +1,16 @@
+import { IsArray, IsBoolean, IsOptional, IsString } from 'class-validator';
+
+export class FeatureFlagDto {
+  @IsBoolean()
+  isProtected: boolean;
+
+  /**
+   * When provided, the same isProtected value is also applied to each listed
+   * subpage slug in the same request. Used by the dashboard to cascade the
+   * service-level toggle to all subpages in one atomic operation.
+   */
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  subpageSlugs?: string[];
+}

--- a/src/forms/dto/index.ts
+++ b/src/forms/dto/index.ts
@@ -1,2 +1,3 @@
 export * from './form-submission.dto';
 export * from './form-submission-response.dto';
+export * from './feature-flag.dto';

--- a/src/forms/expression-resolver.service.ts
+++ b/src/forms/expression-resolver.service.ts
@@ -15,7 +15,7 @@ export interface ExpressionContext {
 export class ExpressionResolverService {
   private readonly logger = new Logger(ExpressionResolverService.name);
 
-  constructor(private readonly configService: ConfigService) { }
+  constructor(private readonly configService: ConfigService) {}
 
   /**
    * Resolve any expression with support for:
@@ -143,8 +143,9 @@ export class ExpressionResolverService {
         ? this.getNestedValue(context.formData, dateFieldPath)
         : undefined;
 
-      const ageInYears =
-        dateValue ? this.calculateAgeInYears(String(dateValue)) : NaN;
+      const ageInYears = dateValue
+        ? this.calculateAgeInYears(String(dateValue))
+        : NaN;
 
       // NaN comparisons are always false, so missing/invalid dates fall through to falseDbRef
       const selectedDbRef =

--- a/src/forms/forms.module.ts
+++ b/src/forms/forms.module.ts
@@ -3,15 +3,29 @@ import { DatabaseModule } from '../database/database.module';
 import { ValidationModule } from '../validation/validation.module';
 import { ProcessorsModule } from '../processors/processors.module';
 import { MetricsModule } from '../metrics/metrics.module';
+import { AuthModule } from '../auth/auth.module';
 import { FormsController } from './forms.controller';
 import { FormsService } from './forms.service';
 import { FormUtilsService } from './form-utils.service';
 import { ExpressionResolverService } from './expression-resolver.service';
+import { ServiceAccessService } from './service-access.service';
+import { ServicesController } from './services.controller';
 
 @Module({
-  imports: [DatabaseModule, ValidationModule, ProcessorsModule, MetricsModule],
-  controllers: [FormsController],
-  providers: [FormsService, FormUtilsService, ExpressionResolverService],
+  imports: [
+    DatabaseModule,
+    ValidationModule,
+    ProcessorsModule,
+    MetricsModule,
+    AuthModule,
+  ],
+  controllers: [FormsController, ServicesController],
+  providers: [
+    FormsService,
+    FormUtilsService,
+    ExpressionResolverService,
+    ServiceAccessService,
+  ],
   exports: [FormsService, FormUtilsService, ExpressionResolverService],
 })
 export class FormsModule {}

--- a/src/forms/service-access.service.ts
+++ b/src/forms/service-access.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Not, type Repository } from 'typeorm';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { type DataSource, Not, type Repository } from 'typeorm';
 import { ServiceAccess } from '../database/entities';
 import type { FeatureFlagDto } from './dto';
 
@@ -29,6 +29,8 @@ export class ServiceAccessService {
   constructor(
     @InjectRepository(ServiceAccess)
     private serviceAccessRepository: Repository<ServiceAccess>,
+    @InjectDataSource()
+    private dataSource: DataSource,
   ) {}
 
   /**
@@ -119,14 +121,16 @@ export class ServiceAccessService {
       ...(dto.subpageSlugs ?? []),
     ];
 
-    await Promise.all(
-      slugsToUpdate.map((subpageSlug) =>
-        this.upsertRow(serviceSlug, subpageSlug, dto.isProtected),
-      ),
-    );
+    const allRows = await this.dataSource.transaction(async (manager) => {
+      const repo = manager.getRepository(ServiceAccess);
 
-    const allRows = await this.serviceAccessRepository.find({
-      where: { serviceSlug },
+      await Promise.all(
+        slugsToUpdate.map((subpageSlug) =>
+          this.upsertRow(repo, serviceSlug, subpageSlug, dto.isProtected),
+        ),
+      );
+
+      return repo.find({ where: { serviceSlug } });
     });
 
     return this.toSummary(serviceSlug, allRows);
@@ -143,7 +147,12 @@ export class ServiceAccessService {
     subpageSlug: string,
     dto: FeatureFlagDto,
   ): Promise<ServiceAccessSummary> {
-    await this.upsertRow(serviceSlug, subpageSlug, dto.isProtected);
+    await this.upsertRow(
+      this.serviceAccessRepository,
+      serviceSlug,
+      subpageSlug,
+      dto.isProtected,
+    );
 
     const allRows = await this.serviceAccessRepository.find({
       where: { serviceSlug },
@@ -154,24 +163,19 @@ export class ServiceAccessService {
 
   /** Shared upsert logic used by both service-level and subpage-level toggles. */
   private async upsertRow(
+    repo: Repository<ServiceAccess>,
     serviceSlug: string,
     subpageSlug: string,
     isProtected: boolean,
   ): Promise<void> {
-    const existing = await this.serviceAccessRepository.findOne({
+    const existing = await repo.findOne({
       where: { serviceSlug, subpageSlug },
     });
 
     if (existing) {
-      await this.serviceAccessRepository.update(existing.id, { isProtected });
+      await repo.update(existing.id, { isProtected });
     } else {
-      await this.serviceAccessRepository.save(
-        this.serviceAccessRepository.create({
-          serviceSlug,
-          subpageSlug,
-          isProtected,
-        }),
-      );
+      await repo.save(repo.create({ serviceSlug, subpageSlug, isProtected }));
     }
   }
 

--- a/src/forms/service-access.service.ts
+++ b/src/forms/service-access.service.ts
@@ -168,15 +168,10 @@ export class ServiceAccessService {
     subpageSlug: string,
     isProtected: boolean,
   ): Promise<void> {
-    const existing = await repo.findOne({
-      where: { serviceSlug, subpageSlug },
-    });
-
-    if (existing) {
-      await repo.update(existing.id, { isProtected });
-    } else {
-      await repo.save(repo.create({ serviceSlug, subpageSlug, isProtected }));
-    }
+    await repo.upsert({ serviceSlug, subpageSlug, isProtected }, [
+      'serviceSlug',
+      'subpageSlug',
+    ]);
   }
 
   private toSummary(

--- a/src/forms/service-access.service.ts
+++ b/src/forms/service-access.service.ts
@@ -1,0 +1,198 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Not, type Repository } from 'typeorm';
+import { ServiceAccess } from '../database/entities';
+import type { FeatureFlagDto } from './dto';
+
+export type SubpageAccessEntry = {
+  slug: string;
+  isProtected: boolean;
+};
+
+/**
+ * The full protection config for a single service.
+ *
+ * isProtected  — controls whether the service is hidden from category listings
+ * subpages     — per-subpage protection; absence of an entry means unprotected
+ */
+export type ServiceAccessSummary = {
+  serviceSlug: string;
+  isProtected: boolean;
+  subpages: SubpageAccessEntry[];
+};
+
+@Injectable()
+export class ServiceAccessService {
+  /** Sentinel for a service-level row, which controls category listing visibility */
+  private static readonly SERVICE_LEVEL_SLUG = '';
+
+  constructor(
+    @InjectRepository(ServiceAccess)
+    private serviceAccessRepository: Repository<ServiceAccess>,
+  ) {}
+
+  /**
+   * Returns the full protection config for every service that has at least one
+   * entry in the database. Services absent from the DB are implicitly unprotected.
+   */
+  async findAll(): Promise<ServiceAccessSummary[]> {
+    const rows = await this.serviceAccessRepository.find();
+
+    const byService = new Map<string, ServiceAccess[]>();
+    for (const row of rows) {
+      const group = byService.get(row.serviceSlug) ?? [];
+      group.push(row);
+      byService.set(row.serviceSlug, group);
+    }
+
+    return Array.from(byService.entries()).map(([serviceSlug, group]) =>
+      this.toSummary(serviceSlug, group),
+    );
+  }
+
+  /**
+   * Returns the full protection config for one service, or null if the service
+   * has no entries in the database (implicitly unprotected).
+   */
+  async findConfigForService(
+    serviceSlug: string,
+  ): Promise<ServiceAccessSummary | null> {
+    const rows = await this.serviceAccessRepository.find({
+      where: { serviceSlug },
+    });
+
+    if (rows.length === 0) {
+      return null;
+    }
+
+    return this.toSummary(serviceSlug, rows);
+  }
+
+  /** Returns false if no service-level row exists — absence means unprotected. */
+  async isServiceProtected(serviceSlug: string): Promise<boolean> {
+    const row = await this.serviceAccessRepository.findOne({
+      where: {
+        serviceSlug,
+        subpageSlug: ServiceAccessService.SERVICE_LEVEL_SLUG,
+      },
+    });
+    return row?.isProtected ?? false;
+  }
+
+  /** Returns false if no subpage-level row exists — absence means unprotected. */
+  async isSubpageProtected(
+    serviceSlug: string,
+    subpageSlug: string,
+  ): Promise<boolean> {
+    const row = await this.serviceAccessRepository.findOne({
+      where: { serviceSlug, subpageSlug },
+    });
+    return row?.isProtected ?? false;
+  }
+
+  async hasProtectedSubpages(serviceSlug: string): Promise<boolean> {
+    const count = await this.serviceAccessRepository.count({
+      where: {
+        serviceSlug,
+        subpageSlug: Not(ServiceAccessService.SERVICE_LEVEL_SLUG),
+        isProtected: true,
+      },
+    });
+    return count > 0;
+  }
+
+  /**
+   * Sets the service-level isProtected flag for a service.
+   *
+   * When dto.subpageSlugs is provided, the same flag value is also applied to
+   * each listed subpage in the same operation — allowing the dashboard to
+   * cascade the service toggle to all subpages atomically.
+   *
+   * Returns the updated full config for the service.
+   */
+  async upsertFeatureFlag(
+    serviceSlug: string,
+    dto: FeatureFlagDto,
+  ): Promise<ServiceAccessSummary> {
+    const slugsToUpdate = [
+      ServiceAccessService.SERVICE_LEVEL_SLUG,
+      ...(dto.subpageSlugs ?? []),
+    ];
+
+    await Promise.all(
+      slugsToUpdate.map((subpageSlug) =>
+        this.upsertRow(serviceSlug, subpageSlug, dto.isProtected),
+      ),
+    );
+
+    const allRows = await this.serviceAccessRepository.find({
+      where: { serviceSlug },
+    });
+
+    return this.toSummary(serviceSlug, allRows);
+  }
+
+  /**
+   * Sets the isProtected flag for a specific subpage of a service.
+   *
+   * Creates the subpage row if one does not exist yet (upsert).
+   * Returns the updated full config for the service.
+   */
+  async upsertSubpageFeatureFlag(
+    serviceSlug: string,
+    subpageSlug: string,
+    dto: FeatureFlagDto,
+  ): Promise<ServiceAccessSummary> {
+    await this.upsertRow(serviceSlug, subpageSlug, dto.isProtected);
+
+    const allRows = await this.serviceAccessRepository.find({
+      where: { serviceSlug },
+    });
+
+    return this.toSummary(serviceSlug, allRows);
+  }
+
+  /** Shared upsert logic used by both service-level and subpage-level toggles. */
+  private async upsertRow(
+    serviceSlug: string,
+    subpageSlug: string,
+    isProtected: boolean,
+  ): Promise<void> {
+    const existing = await this.serviceAccessRepository.findOne({
+      where: { serviceSlug, subpageSlug },
+    });
+
+    if (existing) {
+      await this.serviceAccessRepository.update(existing.id, { isProtected });
+    } else {
+      await this.serviceAccessRepository.save(
+        this.serviceAccessRepository.create({
+          serviceSlug,
+          subpageSlug,
+          isProtected,
+        }),
+      );
+    }
+  }
+
+  private toSummary(
+    serviceSlug: string,
+    rows: ServiceAccess[],
+  ): ServiceAccessSummary {
+    const serviceRow = rows.find(
+      (r) => r.subpageSlug === ServiceAccessService.SERVICE_LEVEL_SLUG,
+    );
+    const subpageRows = rows.filter(
+      (r) => r.subpageSlug !== ServiceAccessService.SERVICE_LEVEL_SLUG,
+    );
+
+    return {
+      serviceSlug,
+      isProtected: serviceRow?.isProtected ?? false,
+      subpages: subpageRows.map((r) => ({
+        slug: r.subpageSlug,
+        isProtected: r.isProtected,
+      })),
+    };
+  }
+}

--- a/src/forms/services.controller.ts
+++ b/src/forms/services.controller.ts
@@ -27,9 +27,7 @@ export class ServicesController {
   async getAllServiceAccess() {
     const configs = await this.serviceAccessService.findAll();
     this.logger.log(
-      `GET /services → returning ${
-        configs.length
-      } service config(s): ${JSON.stringify(configs)}`,
+      `GET /services → returning ${configs.length} service config(s)`,
     );
     return ApiResponse.success(configs, 'Service access configs retrieved');
   }
@@ -50,7 +48,9 @@ export class ServicesController {
       );
     }
 
-    this.logger.log(`GET /services/${serviceSlug} → ${JSON.stringify(config)}`);
+    this.logger.log(
+      `GET /services/${serviceSlug} → returning service slug: ${serviceSlug}`,
+    );
     return ApiResponse.success(config, 'Service access config retrieved');
   }
 

--- a/src/forms/services.controller.ts
+++ b/src/forms/services.controller.ts
@@ -1,0 +1,112 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  NotFoundException,
+  Param,
+  Patch,
+  UseGuards,
+  BadRequestException,
+} from '@nestjs/common';
+import { ApiResponse } from '../common/dto';
+import { CognitoGuard } from '../auth/cognito.guard';
+import { ServiceAccessService } from './service-access.service';
+import { FeatureFlagDto } from './dto';
+
+@Controller('services')
+export class ServicesController {
+  private readonly logger = new Logger(ServicesController.name);
+
+  constructor(private readonly serviceAccessService: ServiceAccessService) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  async getAllServiceAccess() {
+    const configs = await this.serviceAccessService.findAll();
+    this.logger.log(
+      `GET /services → returning ${
+        configs.length
+      } service config(s): ${JSON.stringify(configs)}`,
+    );
+    return ApiResponse.success(configs, 'Service access configs retrieved');
+  }
+
+  @Get(':serviceSlug')
+  @HttpCode(HttpStatus.OK)
+  async getServiceAccess(@Param('serviceSlug') serviceSlug: string) {
+    const config = await this.serviceAccessService.findConfigForService(
+      serviceSlug,
+    );
+
+    if (!config) {
+      this.logger.log(
+        `GET /services/${serviceSlug} → 404 (no DB entry, treated as unprotected)`,
+      );
+      throw new NotFoundException(
+        `No access config found for service: ${serviceSlug}`,
+      );
+    }
+
+    this.logger.log(`GET /services/${serviceSlug} → ${JSON.stringify(config)}`);
+    return ApiResponse.success(config, 'Service access config retrieved');
+  }
+
+  /**
+   * Toggles the service-level feature flag (isProtected) for a service.
+   *
+   * Requires a valid Cognito access token — this is the only write endpoint
+   * on the services resource. Read endpoints remain open for the frontend.
+   */
+  @Patch(':serviceSlug/feature-flag')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(CognitoGuard)
+  async updateFeatureFlag(
+    @Param('serviceSlug') serviceSlug: string,
+    @Body() dto: FeatureFlagDto,
+  ) {
+    const updated = await this.serviceAccessService.upsertFeatureFlag(
+      serviceSlug,
+      dto,
+    );
+
+    this.logger.log(
+      `PATCH /services/${serviceSlug}/feature-flag → isProtected=${dto.isProtected}`,
+    );
+
+    return ApiResponse.success(updated, 'Feature flag updated');
+  }
+
+  /**
+   * Toggles the feature flag for a specific subpage of a service.
+   *
+   * Allows a subpage to be protected independently of the service-level flag,
+   * e.g. the /form subpage can be hidden while /start remains public.
+   */
+  @Patch(':serviceSlug/subpages/:subpageSlug/feature-flag')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(CognitoGuard)
+  async updateSubpageFeatureFlag(
+    @Param('serviceSlug') serviceSlug: string,
+    @Param('subpageSlug') subpageSlug: string,
+    @Body() dto: FeatureFlagDto,
+  ) {
+    if (!subpageSlug) {
+      throw new BadRequestException('subpageSlug must not be empty');
+    }
+
+    const updated = await this.serviceAccessService.upsertSubpageFeatureFlag(
+      serviceSlug,
+      subpageSlug,
+      dto,
+    );
+
+    this.logger.log(
+      `PATCH /services/${serviceSlug}/subpages/${subpageSlug}/feature-flag → isProtected=${dto.isProtected}`,
+    );
+
+    return ApiResponse.success(updated, 'Subpage feature flag updated');
+  }
+}

--- a/src/validation/schema-builder.service.spec.ts
+++ b/src/validation/schema-builder.service.spec.ts
@@ -329,11 +329,10 @@ describe('SchemaBuilderService', () => {
 
     it('in', () => {
       const schema = service.buildZodSchema(
-        requiredWhenOperatorFormSchema(
-          'in',
-          'Required when x is a or b',
-          ['a', 'b'],
-        ),
+        requiredWhenOperatorFormSchema('in', 'Required when x is a or b', [
+          'a',
+          'b',
+        ]),
       );
       const resultFail = service.validateData(schema, {
         x: 'a',


### PR DESCRIPTION
## Description
Introduces a feature flagging system that allows 
- services and their subpages to be individually marked as protected (hidden from listings / access-gated). 
- A new `ServicesController` exposes read endpoints (open to the frontend) and write endpoints protected by a new `CognitoGuard` that validates AWS Cognito-issued JWT access tokens. 
- Protection state is persisted in a new `service_access_configs` table via a `ServiceAccess` entity and `ServiceAccessService`.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

### `src/auth/auth.module.ts` _(new)_
New NestJS module that provides and exports `CognitoGuard`.

### `src/auth/cognito.guard.ts` _(new)_
`CanActivate` guard that validates Bearer tokens against AWS Cognito's JWKS endpoint using `aws-jwt-verify`. Applied only to write (PATCH) endpoints — read endpoints remain open for the frontend.

### `src/database/entities/service-access.entity.ts` _(new)_
TypeORM entity for the `service_access_configs` table. Stores protection config at two levels of granularity: service-level (empty `subpageSlug`) and subpage-level (e.g. `"form"`). Absence of a row defaults to unprotected.

### `src/database/migrations/1769600000000-CreateServiceAccessConfigsTable.ts` _(new)_
Migration that creates the `service_access_configs` table with a unique composite index on `(service_slug, subpage_slug)`.

### `src/forms/service-access.service.ts` _(new)_
Business logic layer for querying and upserting service/subpage protection state. Includes helper methods (`isServiceProtected`, `isSubpageProtected`, `hasProtectedSubpages`) for use by the frontend-facing API.

### `src/forms/services.controller.ts` _(new)_
REST controller (`/services`) with four endpoints:
- `GET /services` — list all configs (open)
- `GET /services/:serviceSlug` — get config for a single service (open)
- `PATCH /services/:serviceSlug/feature-flag` — toggle service-level protection, with optional cascade to subpages (Cognito-gated)
- `PATCH /services/:serviceSlug/subpages/:subpageSlug/feature-flag` — toggle subpage-level protection independently (Cognito-gated)

### `src/forms/dto/feature-flag.dto.ts` _(new)_
Request DTO for the PATCH endpoints. Accepts `isProtected` (boolean) and an optional `subpageSlugs` array for atomic cascade operations.

### `src/config/configuration.ts`
Added `cognito.userPoolId` and `cognito.clientId` config keys sourced from `AWS_COGNITO_USER_POOL_ID` and `AWS_COGNITO_CLIENT_ID` environment variables.

### `src/app.module.ts`, `src/forms/forms.module.ts`, `src/database/database.module.ts`
Wired up the new `AuthModule`, `ServicesController`, `ServiceAccessService`, and `ServiceAccess` entity into the module graph.

### `package.json`
Added `aws-jwt-verify@^5.1.1` dependency for Cognito JWT validation.

### `src/email/email.service.ts`, `src/forms/expression-resolver.service.ts`, `src/validation/schema-builder.service.spec.ts`
Formatting-only changes (Prettier: space before function parens, multiline argument alignment).

### Notes
- Read endpoints (`GET /services`, `GET /services/:serviceSlug`) are intentionally unauthenticated so the `alpha-preview` frontend can query protection state without user context.
- The `AWS_COGNITO_USER_POOL_ID` and `AWS_COGNITO_CLIENT_ID` environment variables must be set in production; the app will throw at startup if they are missing and the guard is instantiated.

## Testing
- [ ] Manually test API routes

## Related Github Issue(s)/Trello Ticket(s)
[<!-- Link any related issues: Fixes #123 -->](https://trello.com/c/7dbIKRhd/626-deploy-service-dashboard-with-feature-flagging-ui-to-development-environment)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated