### PR TITLE
fix (forms): make reason for applying mandatory in birth certificate form

### DIFF
--- a/schemas/get-birth-certificate.json
+++ b/schemas/get-birth-certificate.json
@@ -150,7 +150,7 @@
       "name": "reasonForOrderingCertificate",
       "type": "string",
       "label": "Tell us why you're ordering a birth certificate",
-      "required": false,
+      "required": true,
       "validations": {
         "message": ""
       }


### PR DESCRIPTION
## Description
This PR is for a specification change which required the field "reasonForOrderingCertificate" to be mandatory in the "Birth Certificate" form field

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

<!--List the files changed and why -->
Update `reasonForOrderingCertificate` field to `required: true`

### Notes
<!--Add notes for anything unrelated to the specified categories -->

## Testing
- [x] Manual tests completed
- [ ] Added unit tests
- [ ] Added e2e tests

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->
https://trello.com/c/UK6cHtMG/7-mandatory-field-missing-in-apply-for-a-copy-of-a-birth-certificate

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated
