### PR TITLE
feat: add audit logging for feature flags

### DIFF
--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { FormConfig, ServiceAccess } from './entities';
+import { FeatureFlagAuditLog, FormConfig, ServiceAccess } from './entities';
 import { dataSource } from './datasource';
 
 @Module({
@@ -11,7 +11,7 @@ import { dataSource } from './datasource';
       },
       dataSourceFactory: () => dataSource.initialize(),
     }),
-    TypeOrmModule.forFeature([FormConfig, ServiceAccess]),
+    TypeOrmModule.forFeature([FeatureFlagAuditLog, FormConfig, ServiceAccess]),
   ],
   exports: [TypeOrmModule],
 })

--- a/src/database/entities/feature-flag-audit-log.entity.ts
+++ b/src/database/entities/feature-flag-audit-log.entity.ts
@@ -31,6 +31,10 @@ export class FeatureFlagAuditLog {
   @Column({ name: 'performed_by', type: 'varchar', length: 255 })
   performedBy: string;
 
+  /** Human-readable display name supplied by the client (from ID token profile). */
+  @Column({ name: 'performed_by_name', type: 'varchar', length: 255, nullable: true })
+  performedByName: string | null;
+
   @Index()
   @CreateDateColumn({ name: 'performed_at', type: 'timestamptz' })
   performedAt: Date;

--- a/src/database/entities/feature-flag-audit-log.entity.ts
+++ b/src/database/entities/feature-flag-audit-log.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('feature_flag_audit_log')
+export class FeatureFlagAuditLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index()
+  @Column({ name: 'service_slug', type: 'varchar', length: 255 })
+  serviceSlug: string;
+
+  /** null for service-level toggles */
+  @Column({ name: 'subpage_slug', type: 'varchar', length: 255, nullable: true })
+  subpageSlug: string | null;
+
+  /** "service" for service-level toggles, "subpage" for subpage-level */
+  @Column({ type: 'varchar', length: 20 })
+  scope: 'service' | 'subpage';
+
+  /** "enable" when flag was turned on, "disable" when turned off */
+  @Column({ type: 'varchar', length: 20 })
+  action: 'enable' | 'disable';
+
+  @Index()
+  @Column({ name: 'performed_by', type: 'varchar', length: 255 })
+  performedBy: string;
+
+  @Index()
+  @CreateDateColumn({ name: 'performed_at', type: 'timestamptz' })
+  performedAt: Date;
+}

--- a/src/database/entities/index.ts
+++ b/src/database/entities/index.ts
@@ -1,3 +1,4 @@
+export * from './feature-flag-audit-log.entity';
 export * from './form-config.entity';
 export * from './payment.entity';
 export * from './payment-transaction.entity';

--- a/src/database/entities/service-access.entity.ts
+++ b/src/database/entities/service-access.entity.ts
@@ -15,7 +15,7 @@ import {
  *
  * Absence of a row defaults to unprotected (fail open).
  */
-@Entity('service_access_configs')
+@Entity('feature_flags')
 @Index(['serviceSlug', 'subpageSlug'], { unique: true })
 export class ServiceAccess {
   @PrimaryGeneratedColumn('uuid')

--- a/src/database/migrations/1775980800000-CreateFeatureFlagAuditLogTable.ts
+++ b/src/database/migrations/1775980800000-CreateFeatureFlagAuditLogTable.ts
@@ -1,0 +1,94 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateFeatureFlagAuditLogTable1775980800000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'feature_flag_audit_log',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'service_slug',
+            type: 'varchar',
+            length: '255',
+          },
+          {
+            name: 'subpage_slug',
+            type: 'varchar',
+            length: '255',
+            isNullable: true,
+          },
+          {
+            name: 'scope',
+            type: 'varchar',
+            length: '20',
+          },
+          {
+            name: 'action',
+            type: 'varchar',
+            length: '20',
+          },
+          {
+            name: 'performed_by',
+            type: 'varchar',
+            length: '255',
+          },
+          {
+            name: 'performed_at',
+            type: 'timestamptz',
+            default: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'feature_flag_audit_log',
+      new TableIndex({
+        name: 'IDX_AUDIT_LOG_SERVICE_SLUG',
+        columnNames: ['service_slug'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'feature_flag_audit_log',
+      new TableIndex({
+        name: 'IDX_AUDIT_LOG_PERFORMED_AT',
+        columnNames: ['performed_at'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'feature_flag_audit_log',
+      new TableIndex({
+        name: 'IDX_AUDIT_LOG_PERFORMED_BY',
+        columnNames: ['performed_by'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex(
+      'feature_flag_audit_log',
+      'IDX_AUDIT_LOG_PERFORMED_BY',
+    );
+    await queryRunner.dropIndex(
+      'feature_flag_audit_log',
+      'IDX_AUDIT_LOG_PERFORMED_AT',
+    );
+    await queryRunner.dropIndex(
+      'feature_flag_audit_log',
+      'IDX_AUDIT_LOG_SERVICE_SLUG',
+    );
+    await queryRunner.dropTable('feature_flag_audit_log');
+  }
+}

--- a/src/database/migrations/1776067200000-RenameServiceAccessConfigsToFeatureFlags.ts
+++ b/src/database/migrations/1776067200000-RenameServiceAccessConfigsToFeatureFlags.ts
@@ -1,0 +1,13 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RenameServiceAccessConfigsToFeatureFlags1776067200000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.renameTable('service_access_configs', 'feature_flags');
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.renameTable('feature_flags', 'service_access_configs');
+  }
+}

--- a/src/database/migrations/1776067800000-AddFeatureFlagsAuditTrigger.ts
+++ b/src/database/migrations/1776067800000-AddFeatureFlagsAuditTrigger.ts
@@ -1,0 +1,79 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddFeatureFlagsAuditTrigger1776067800000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE OR REPLACE FUNCTION log_feature_flag_change()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $$
+      DECLARE
+        resolved_scope varchar(20);
+        resolved_action varchar(20);
+        resolved_subpage_slug varchar(255);
+        resolved_actor varchar(255);
+      BEGIN
+        IF TG_OP = 'UPDATE' AND NEW.is_protected IS NOT DISTINCT FROM OLD.is_protected THEN
+          RETURN NEW;
+        END IF;
+
+        resolved_scope := CASE
+          WHEN NEW.subpage_slug = '' THEN 'service'
+          ELSE 'subpage'
+        END;
+
+        resolved_subpage_slug := CASE
+          WHEN NEW.subpage_slug = '' THEN NULL
+          ELSE NEW.subpage_slug
+        END;
+
+        resolved_action := CASE
+          WHEN NEW.is_protected THEN 'enable'
+          ELSE 'disable'
+        END;
+
+        resolved_actor := COALESCE(
+          NULLIF(current_setting('app.audit_actor', true), ''),
+          'system/db-client'
+        );
+
+        INSERT INTO feature_flag_audit_log (
+          service_slug,
+          subpage_slug,
+          scope,
+          action,
+          performed_by
+        )
+        VALUES (
+          NEW.service_slug,
+          resolved_subpage_slug,
+          resolved_scope,
+          resolved_action,
+          resolved_actor
+        );
+
+        RETURN NEW;
+      END;
+      $$;
+    `);
+
+    await queryRunner.query(`
+      CREATE TRIGGER trigger_log_feature_flag_change
+      AFTER INSERT OR UPDATE ON feature_flags
+      FOR EACH ROW
+      EXECUTE FUNCTION log_feature_flag_change();
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP TRIGGER IF EXISTS trigger_log_feature_flag_change ON feature_flags;
+    `);
+
+    await queryRunner.query(`
+      DROP FUNCTION IF EXISTS log_feature_flag_change();
+    `);
+  }
+}

--- a/src/database/migrations/1776153600000-AddPerformedByNameToAuditLog.ts
+++ b/src/database/migrations/1776153600000-AddPerformedByNameToAuditLog.ts
@@ -1,0 +1,19 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddPerformedByNameToAuditLog1776153600000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE feature_flag_audit_log
+      ADD COLUMN performed_by_name VARCHAR(255) DEFAULT NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE feature_flag_audit_log
+      DROP COLUMN performed_by_name
+    `);
+  }
+}

--- a/src/forms/audit-log.controller.spec.ts
+++ b/src/forms/audit-log.controller.spec.ts
@@ -1,0 +1,92 @@
+import { UnauthorizedException } from '@nestjs/common';
+import type { Request } from 'express';
+import { AuditLogController } from './audit-log.controller';
+import type { AuditLogService } from './audit-log.service';
+import type { CreateAuditLogDto } from './dto';
+
+jest.mock('../auth/cognito.guard', () => ({
+  CognitoGuard: class MockCognitoGuard {},
+}));
+
+type MockAuditLogService = {
+  create: jest.Mock;
+  findAll: jest.Mock;
+};
+
+describe('AuditLogController', () => {
+  let controller: AuditLogController;
+  let service: MockAuditLogService;
+
+  beforeEach(() => {
+    service = {
+      create: jest.fn(),
+      findAll: jest.fn(),
+    };
+    controller = new AuditLogController(service as unknown as AuditLogService);
+  });
+
+  it('creates audit entry using actor from cognito claims', async () => {
+    const dto: CreateAuditLogDto = {
+      serviceSlug: 'birth-certificate',
+      scope: 'service',
+      action: 'enable',
+    };
+    service.create.mockResolvedValue({ id: 'entry-1' });
+
+    const request = {
+      cognitoClaims: { email: 'auditor@example.com' },
+    } as unknown as Request;
+
+    await controller.create(dto, request);
+
+    expect(service.create).toHaveBeenCalledWith(dto, 'auditor@example.com');
+  });
+
+  it('falls back to sub claim when email is unavailable', async () => {
+    const dto: CreateAuditLogDto = {
+      serviceSlug: 'passport',
+      scope: 'subpage',
+      action: 'disable',
+      subpageSlug: 'payment',
+    };
+    service.create.mockResolvedValue({ id: 'entry-2' });
+
+    const request = {
+      cognitoClaims: { sub: 'user-sub-id' },
+    } as unknown as Request;
+
+    await controller.create(dto, request);
+
+    expect(service.create).toHaveBeenCalledWith(dto, 'user-sub-id');
+  });
+
+  it('throws when cognito claims are missing', async () => {
+    const dto: CreateAuditLogDto = {
+      serviceSlug: 'passport',
+      scope: 'service',
+      action: 'enable',
+    };
+
+    await expect(controller.create(dto, {} as Request)).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('passes pagination options to service', async () => {
+    service.findAll.mockResolvedValue({
+      entries: [],
+      total: 0,
+      limit: 50,
+      offset: 0,
+      hasMore: false,
+    });
+
+    await controller.findAll('passport', 25, 10);
+
+    expect(service.findAll).toHaveBeenCalledWith({
+      serviceSlug: 'passport',
+      limit: 25,
+      offset: 10,
+    });
+  });
+});

--- a/src/forms/audit-log.controller.ts
+++ b/src/forms/audit-log.controller.ts
@@ -1,0 +1,98 @@
+import {
+  Body,
+  Controller,
+  DefaultValuePipe,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Post,
+  Req,
+  Query,
+  ParseIntPipe,
+  UnauthorizedException,
+  UseGuards,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import { ApiResponse } from '../common/dto';
+import { CognitoGuard } from '../auth/cognito.guard';
+import { AuditLogService } from './audit-log.service';
+import { CreateAuditLogDto } from './dto';
+
+@Controller('audit-logs')
+@UseGuards(CognitoGuard)
+export class AuditLogController {
+  private readonly logger = new Logger(AuditLogController.name);
+
+  constructor(private readonly auditLogService: AuditLogService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async create(@Body() dto: CreateAuditLogDto, @Req() request: Request) {
+    const actor = this.resolveActorFromRequest(request);
+    const entry = await this.auditLogService.create(dto, actor);
+
+    this.logger.log(
+      `POST /audit-logs → ${dto.action} ${dto.scope} flag for ${dto.serviceSlug} by ${actor}`,
+    );
+
+    return ApiResponse.success(entry, 'Audit log entry created');
+  }
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  async findAll(
+    @Query('serviceSlug') serviceSlug?: string,
+    @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit?: number,
+    @Query('offset', new DefaultValuePipe(0), ParseIntPipe) offset?: number,
+  ) {
+    const result = await this.auditLogService.findAll({
+      serviceSlug,
+      limit: limit ?? 50,
+      offset: offset ?? 0,
+    });
+
+    this.logger.log(
+      `GET /audit-logs → returning ${result.entries.length} entries (offset=${
+        result.offset
+      }, limit=${result.limit})${serviceSlug ? ` for ${serviceSlug}` : ''}`,
+    );
+
+    return ApiResponse.success(result, 'Audit log entries retrieved');
+  }
+
+  private resolveActorFromRequest(request: Request): string {
+    const claims = (
+      request as Request & { cognitoClaims?: Record<string, unknown> }
+    ).cognitoClaims;
+
+    if (!claims) {
+      throw new UnauthorizedException('Missing Cognito claims in request');
+    }
+
+    const actor =
+      this.readStringClaim(claims, 'email') ??
+      this.readStringClaim(claims, 'username') ??
+      this.readStringClaim(claims, 'cognito:username') ??
+      this.readStringClaim(claims, 'sub');
+
+    if (!actor) {
+      throw new UnauthorizedException('No usable actor claim found in token');
+    }
+
+    return actor;
+  }
+
+  private readStringClaim(
+    claims: Record<string, unknown>,
+    key: string,
+  ): string | null {
+    const value = claims[key];
+    if (typeof value !== 'string') {
+      return null;
+    }
+
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+}

--- a/src/forms/audit-log.service.spec.ts
+++ b/src/forms/audit-log.service.spec.ts
@@ -1,0 +1,114 @@
+import { BadRequestException } from '@nestjs/common';
+import { AuditLogService } from './audit-log.service';
+import type { CreateAuditLogDto } from './dto';
+import type { FeatureFlagAuditLog } from '../database/entities';
+
+type MockRepository = {
+  create: jest.Mock;
+  save: jest.Mock;
+  findAndCount: jest.Mock;
+};
+
+describe('AuditLogService', () => {
+  let service: AuditLogService;
+  let repository: MockRepository;
+
+  beforeEach(() => {
+    repository = {
+      create: jest.fn(),
+      save: jest.fn(),
+      findAndCount: jest.fn(),
+    };
+    service = new AuditLogService(repository as never);
+  });
+
+  it('creates a service-scope entry with null subpage slug', async () => {
+    const dto: CreateAuditLogDto = {
+      serviceSlug: 'birth-certificate',
+      scope: 'service',
+      action: 'enable',
+    };
+
+    const createdEntry = { id: '1' } as FeatureFlagAuditLog;
+    repository.create.mockReturnValue(createdEntry);
+    repository.save.mockResolvedValue(createdEntry);
+
+    const result = await service.create(dto, 'auditor@example.com');
+
+    expect(repository.create).toHaveBeenCalledWith({
+      serviceSlug: 'birth-certificate',
+      subpageSlug: null,
+      scope: 'service',
+      action: 'enable',
+      performedBy: 'auditor@example.com',
+    });
+    expect(result).toBe(createdEntry);
+  });
+
+  it('rejects subpageSlug for service scope', async () => {
+    const dto: CreateAuditLogDto = {
+      serviceSlug: 'birth-certificate',
+      scope: 'service',
+      action: 'disable',
+      subpageSlug: 'form',
+    };
+
+    await expect(service.create(dto, 'auditor@example.com')).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('requires subpageSlug for subpage scope', async () => {
+    const dto: CreateAuditLogDto = {
+      serviceSlug: 'birth-certificate',
+      scope: 'subpage',
+      action: 'disable',
+    };
+
+    await expect(service.create(dto, 'auditor@example.com')).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('returns paginated audit logs with metadata', async () => {
+    const entries = [{ id: '1' }, { id: '2' }] as FeatureFlagAuditLog[];
+    repository.findAndCount.mockResolvedValue([entries, 12]);
+
+    const result = await service.findAll({
+      serviceSlug: 'birth-certificate',
+      limit: 2,
+      offset: 4,
+    });
+
+    expect(repository.findAndCount).toHaveBeenCalledWith({
+      where: { serviceSlug: 'birth-certificate' },
+      order: { performedAt: 'DESC' },
+      take: 2,
+      skip: 4,
+    });
+    expect(result).toEqual({
+      entries,
+      total: 12,
+      limit: 2,
+      offset: 4,
+      hasMore: true,
+    });
+  });
+
+  it('caps limit at 200 entries', async () => {
+    repository.findAndCount.mockResolvedValue([[], 0]);
+
+    await service.findAll({
+      serviceSlug: undefined,
+      limit: 1000,
+      offset: 0,
+    });
+
+    expect(repository.findAndCount).toHaveBeenCalledWith({
+      where: undefined,
+      order: { performedAt: 'DESC' },
+      take: 200,
+      skip: 0,
+    });
+  });
+});

--- a/src/forms/audit-log.service.spec.ts
+++ b/src/forms/audit-log.service.spec.ts
@@ -41,6 +41,7 @@ describe('AuditLogService', () => {
       scope: 'service',
       action: 'enable',
       performedBy: 'auditor@example.com',
+      performedByName: null,
     });
     expect(result).toBe(createdEntry);
   });

--- a/src/forms/audit-log.service.ts
+++ b/src/forms/audit-log.service.ts
@@ -1,0 +1,101 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import type { FindOptionsWhere, Repository } from 'typeorm';
+import { FeatureFlagAuditLog } from '../database/entities';
+import type { CreateAuditLogDto } from './dto';
+
+type AuditLogQueryOptions = {
+  serviceSlug?: string;
+  limit: number;
+  offset: number;
+};
+
+type AuditLogListResult = {
+  entries: FeatureFlagAuditLog[];
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+};
+
+@Injectable()
+export class AuditLogService {
+  constructor(
+    @InjectRepository(FeatureFlagAuditLog)
+    private auditLogRepository: Repository<FeatureFlagAuditLog>,
+  ) {}
+
+  async create(
+    dto: CreateAuditLogDto,
+    performedBy: string,
+  ): Promise<FeatureFlagAuditLog> {
+    const normalizedSubpageSlug = this.resolveSubpageSlug(dto);
+
+    const entry = this.auditLogRepository.create({
+      serviceSlug: dto.serviceSlug,
+      subpageSlug: normalizedSubpageSlug,
+      scope: dto.scope,
+      action: dto.action,
+      performedBy,
+    });
+
+    return this.auditLogRepository.save(entry);
+  }
+
+  async findAll(options: AuditLogQueryOptions): Promise<AuditLogListResult> {
+    const where: FindOptionsWhere<FeatureFlagAuditLog> | undefined =
+      options.serviceSlug ? { serviceSlug: options.serviceSlug } : undefined;
+    const safeLimit = this.resolveLimit(options.limit);
+    const safeOffset = this.resolveOffset(options.offset);
+
+    const [entries, total] = await this.auditLogRepository.findAndCount({
+      where,
+      order: { performedAt: 'DESC' },
+      take: safeLimit,
+      skip: safeOffset,
+    });
+
+    return {
+      entries,
+      total,
+      limit: safeLimit,
+      offset: safeOffset,
+      hasMore: safeOffset + entries.length < total,
+    };
+  }
+
+  private resolveSubpageSlug(dto: CreateAuditLogDto): string | null {
+    const trimmedSubpageSlug = dto.subpageSlug?.trim();
+
+    if (dto.scope === 'service') {
+      if (trimmedSubpageSlug) {
+        throw new BadRequestException(
+          'subpageSlug must be omitted when scope is "service"',
+        );
+      }
+      return null;
+    }
+
+    if (!trimmedSubpageSlug) {
+      throw new BadRequestException(
+        'subpageSlug is required when scope is "subpage"',
+      );
+    }
+
+    return trimmedSubpageSlug;
+  }
+
+  private resolveLimit(limit: number): number {
+    if (!Number.isFinite(limit) || limit <= 0) {
+      throw new BadRequestException('limit must be a positive integer');
+    }
+    return Math.min(Math.floor(limit), 200);
+  }
+
+  private resolveOffset(offset: number): number {
+    if (!Number.isFinite(offset) || offset < 0) {
+      throw new BadRequestException('offset must be zero or greater');
+    }
+    return Math.floor(offset);
+  }
+}

--- a/src/forms/audit-log.service.ts
+++ b/src/forms/audit-log.service.ts
@@ -37,6 +37,7 @@ export class AuditLogService {
       scope: dto.scope,
       action: dto.action,
       performedBy,
+      performedByName: dto.performedByName?.trim() ?? null,
     });
 
     return this.auditLogRepository.save(entry);

--- a/src/forms/dto/create-audit-log.dto.ts
+++ b/src/forms/dto/create-audit-log.dto.ts
@@ -1,0 +1,18 @@
+import { IsIn, IsNotEmpty, IsString, ValidateIf } from 'class-validator';
+
+export class CreateAuditLogDto {
+  @IsString()
+  @IsNotEmpty()
+  serviceSlug: string;
+
+  @ValidateIf((dto: CreateAuditLogDto) => dto.scope === 'subpage')
+  @IsString()
+  @IsNotEmpty()
+  subpageSlug?: string;
+
+  @IsIn(['service', 'subpage'])
+  scope: 'service' | 'subpage';
+
+  @IsIn(['enable', 'disable'])
+  action: 'enable' | 'disable';
+}

--- a/src/forms/dto/create-audit-log.dto.ts
+++ b/src/forms/dto/create-audit-log.dto.ts
@@ -1,4 +1,10 @@
-import { IsIn, IsNotEmpty, IsString, ValidateIf } from 'class-validator';
+import {
+  IsIn,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateIf,
+} from 'class-validator';
 
 export class CreateAuditLogDto {
   @IsString()
@@ -15,4 +21,19 @@ export class CreateAuditLogDto {
 
   @IsIn(['enable', 'disable'])
   action: 'enable' | 'disable';
+
+  /**
+   * Legacy client field.
+   * The backend ignores this and derives the authoritative actor from Cognito claims.
+   */
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  performedBy?: string;
+
+  /** Human-readable display name from the client's ID token profile. */
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  performedByName?: string;
 }

--- a/src/forms/dto/index.ts
+++ b/src/forms/dto/index.ts
@@ -1,3 +1,4 @@
+export * from './create-audit-log.dto';
 export * from './form-submission.dto';
 export * from './form-submission-response.dto';
 export * from './feature-flag.dto';

--- a/src/forms/forms.module.ts
+++ b/src/forms/forms.module.ts
@@ -4,6 +4,8 @@ import { ValidationModule } from '../validation/validation.module';
 import { ProcessorsModule } from '../processors/processors.module';
 import { MetricsModule } from '../metrics/metrics.module';
 import { AuthModule } from '../auth/auth.module';
+import { AuditLogController } from './audit-log.controller';
+import { AuditLogService } from './audit-log.service';
 import { FormsController } from './forms.controller';
 import { FormsService } from './forms.service';
 import { FormUtilsService } from './form-utils.service';
@@ -19,8 +21,9 @@ import { ServicesController } from './services.controller';
     MetricsModule,
     AuthModule,
   ],
-  controllers: [FormsController, ServicesController],
+  controllers: [AuditLogController, FormsController, ServicesController],
   providers: [
+    AuditLogService,
     FormsService,
     FormUtilsService,
     ExpressionResolverService,

--- a/src/forms/service-access.service.ts
+++ b/src/forms/service-access.service.ts
@@ -1,6 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
-import { type DataSource, Not, type Repository } from 'typeorm';
+import {
+  type DataSource,
+  type EntityManager,
+  Not,
+  type Repository,
+} from 'typeorm';
 import { ServiceAccess } from '../database/entities';
 import type { FeatureFlagDto } from './dto';
 
@@ -115,6 +120,7 @@ export class ServiceAccessService {
   async upsertFeatureFlag(
     serviceSlug: string,
     dto: FeatureFlagDto,
+    performedBy: string,
   ): Promise<ServiceAccessSummary> {
     const slugsToUpdate = [
       ServiceAccessService.SERVICE_LEVEL_SLUG,
@@ -123,6 +129,7 @@ export class ServiceAccessService {
 
     const allRows = await this.dataSource.transaction(async (manager) => {
       const repo = manager.getRepository(ServiceAccess);
+      await this.setAuditActorForTransaction(manager, performedBy);
 
       await Promise.all(
         slugsToUpdate.map((subpageSlug) =>
@@ -146,16 +153,17 @@ export class ServiceAccessService {
     serviceSlug: string,
     subpageSlug: string,
     dto: FeatureFlagDto,
+    performedBy: string,
   ): Promise<ServiceAccessSummary> {
-    await this.upsertRow(
-      this.serviceAccessRepository,
-      serviceSlug,
-      subpageSlug,
-      dto.isProtected,
-    );
+    const allRows = await this.dataSource.transaction(async (manager) => {
+      const repo = manager.getRepository(ServiceAccess);
+      await this.setAuditActorForTransaction(manager, performedBy);
 
-    const allRows = await this.serviceAccessRepository.find({
-      where: { serviceSlug },
+      await this.upsertRow(repo, serviceSlug, subpageSlug, dto.isProtected);
+
+      return repo.find({
+        where: { serviceSlug },
+      });
     });
 
     return this.toSummary(serviceSlug, allRows);
@@ -171,6 +179,15 @@ export class ServiceAccessService {
     await repo.upsert({ serviceSlug, subpageSlug, isProtected }, [
       'serviceSlug',
       'subpageSlug',
+    ]);
+  }
+
+  private async setAuditActorForTransaction(
+    manager: EntityManager,
+    performedBy: string,
+  ): Promise<void> {
+    await manager.query(`SELECT set_config('app.audit_actor', $1, true)`, [
+      performedBy,
     ]);
   }
 

--- a/src/forms/services.controller.ts
+++ b/src/forms/services.controller.ts
@@ -8,9 +8,12 @@ import {
   NotFoundException,
   Param,
   Patch,
+  Req,
+  UnauthorizedException,
   UseGuards,
   BadRequestException,
 } from '@nestjs/common';
+import type { Request } from 'express';
 import { ApiResponse } from '../common/dto';
 import { CognitoGuard } from '../auth/cognito.guard';
 import { ServiceAccessService } from './service-access.service';
@@ -66,10 +69,13 @@ export class ServicesController {
   async updateFeatureFlag(
     @Param('serviceSlug') serviceSlug: string,
     @Body() dto: FeatureFlagDto,
+    @Req() request: Request,
   ) {
+    const actor = this.resolveActorFromRequest(request);
     const updated = await this.serviceAccessService.upsertFeatureFlag(
       serviceSlug,
       dto,
+      actor,
     );
 
     this.logger.log(
@@ -92,15 +98,18 @@ export class ServicesController {
     @Param('serviceSlug') serviceSlug: string,
     @Param('subpageSlug') subpageSlug: string,
     @Body() dto: FeatureFlagDto,
+    @Req() request: Request,
   ) {
     if (!subpageSlug) {
       throw new BadRequestException('subpageSlug must not be empty');
     }
 
+    const actor = this.resolveActorFromRequest(request);
     const updated = await this.serviceAccessService.upsertSubpageFeatureFlag(
       serviceSlug,
       subpageSlug,
       dto,
+      actor,
     );
 
     this.logger.log(
@@ -108,5 +117,40 @@ export class ServicesController {
     );
 
     return ApiResponse.success(updated, 'Subpage feature flag updated');
+  }
+
+  private resolveActorFromRequest(request: Request): string {
+    const claims = (
+      request as Request & { cognitoClaims?: Record<string, unknown> }
+    ).cognitoClaims;
+
+    if (!claims) {
+      throw new UnauthorizedException('Missing Cognito claims in request');
+    }
+
+    const actor =
+      this.readStringClaim(claims, 'email') ??
+      this.readStringClaim(claims, 'username') ??
+      this.readStringClaim(claims, 'cognito:username') ??
+      this.readStringClaim(claims, 'sub');
+
+    if (!actor) {
+      throw new UnauthorizedException('No usable actor claim found in token');
+    }
+
+    return actor;
+  }
+
+  private readStringClaim(
+    claims: Record<string, unknown>,
+    key: string,
+  ): string | null {
+    const value = claims[key];
+    if (typeof value !== 'string') {
+      return null;
+    }
+
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
   }
 }


### PR DESCRIPTION
## Description
Introduces feature-flag audit trail support across the API and database so all service/subpage flag changes can be attributed to a user and queried later.  
Also renames the feature flag storage table for clearer domain naming, adds audit log endpoints/services/tests, and tightens validation in the birth certificate schema plus local env defaults.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

- `.env.example`
  - Updated local defaults (`PORT` and `FRONTEND_URL`) to align with current local setup expectations.

- `schemas/get-birth-certificate.json`
  - Strengthened validation rules for `placeOfBaptism` and father name fields (required flags, min/max constraints, and messages).

- `src/database/database.module.ts`
  - Registered `FeatureFlagAuditLog` entity in TypeORM feature imports.

- `src/database/entities/feature-flag-audit-log.entity.ts` (new)
  - Added audit log entity for tracking actor, action, scope, service/subpage target, and timestamp.

- `src/database/entities/index.ts`
  - Exported new `FeatureFlagAuditLog` entity.

- `src/database/entities/service-access.entity.ts`
  - Updated entity table mapping from `service_access_configs` to `feature_flags`.

- `src/database/migrations/1775980800000-CreateFeatureFlagAuditLogTable.ts` (new)
  - Creates `feature_flag_audit_log` table and indexes for query efficiency.

- `src/database/migrations/1776067200000-RenameServiceAccessConfigsToFeatureFlags.ts` (new)
  - Renames legacy feature flag table to `feature_flags` (with rollback support).

- `src/database/migrations/1776067800000-AddFeatureFlagsAuditTrigger.ts` (new)
  - Adds DB trigger/function to automatically log feature flag changes and derive action/scope metadata.

- `src/forms/audit-log.controller.ts` (new)
  - Added controller endpoints for creating and listing audit log entries.

- `src/forms/audit-log.service.ts` (new)
  - Added audit log service with validation, pagination, filtering, and persistence logic.

- `src/forms/audit-log.controller.spec.ts` (new)
  - Added controller tests for audit log endpoints/behavior.

- `src/forms/audit-log.service.spec.ts` (new)
  - Added service tests for validation, pagination, and data handling.

- `src/forms/dto/create-audit-log.dto.ts` (new)
  - Added DTO for creating audit log entries with scope/action/subpage validation rules.

- `src/forms/dto/index.ts`
  - Exported `CreateAuditLogDto`.

- `src/forms/forms.module.ts`
  - Registered `AuditLogController` and `AuditLogService` in module wiring.

- `src/forms/service-access.service.ts`
  - Updated feature flag mutation flows to accept `performedBy` and set DB session config (`app.audit_actor`) inside transactions for trigger-based attribution.

- `src/forms/services.controller.ts`
  - Extracts actor from Cognito claims and passes it to feature flag service methods; added claim parsing/validation and unauthorized handling.

### Notes
- The primary behavior change is an end-to-end audit pipeline (controller/service + DB trigger + migrations) for feature flag mutations.
- There are also non-audit changes in this diff (`.env.example` defaults and birth-certificate schema validation tightening), which may be unrelated to the audit-trail feature and can be split if desired.

## Testing
- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated